### PR TITLE
Improved wait instruction assembler

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/_controlbox/Assembler.py
+++ b/pycqed/instrument_drivers/physical_instruments/_controlbox/Assembler.py
@@ -514,7 +514,15 @@ class Assembler():
                 self.instructions.append(int(self.MeasureFormat(), 2))
 
             elif (elements[0].lower() == 'wait'):   # Wait imm
-                self.instructions.append(int(self.WaitFormat(elements[1]), 2))
+                if int(elements[1]) < 0:
+                    raise ValueError('Error: wait instruction with negative' +
+                                     ' parameter found on line "{}".'.format(line))
+                elif int(elements[1]) == 0:
+                    # 'wait 0' instruction should be ignored
+                    pass
+                elif int(elements[1]) > 0:
+                    self.instructions.append(
+                        int(self.WaitFormat(elements[1]), 2))
 
             elif (elements[0].lower() == 'trigger'):   # Trigger mask, duration
                 self.instructions.append(int(self.TriggerFormat(elements[1],

--- a/pycqed/tests/test_data/waitTest/waitNegativeTest.qumis
+++ b/pycqed/tests/test_data/waitTest/waitNegativeTest.qumis
@@ -1,0 +1,3 @@
+wait 10
+wait -3
+wait 11

--- a/pycqed/tests/test_data/waitTest/waitZeroTest.qumis
+++ b/pycqed/tests/test_data/waitTest/waitZeroTest.qumis
@@ -1,0 +1,3 @@
+wait 5
+wait 0
+wait 3

--- a/pycqed/tests/test_qumis_assembler.py
+++ b/pycqed/tests/test_qumis_assembler.py
@@ -74,4 +74,4 @@ class Test_single_qubit_seqs(TestCase):
 
         my_asm_obj = asm.Assembler(neg_wait_fname)
         with self.assertRaises(ValueError):
-            my_instructions = my_asm_obj.convert_to_instructions()
+            my_asm_obj.convert_to_instructions()

--- a/pycqed/tests/test_qumis_assembler.py
+++ b/pycqed/tests/test_qumis_assembler.py
@@ -7,6 +7,7 @@ from pycqed.instrument_drivers.physical_instruments._controlbox \
 
 
 class Test_single_qubit_seqs(TestCase):
+
     @classmethod
     def setUpClass(self):
         self.asm_filename = os.path.join(
@@ -15,12 +16,10 @@ class Test_single_qubit_seqs(TestCase):
         self.asm_obj = asm.Assembler(self.asm_filename)
         self.instructions = self.asm_obj.convert_to_instructions()
         self.text_instructions = self.asm_obj.getTextInstructions()
-        print('this is setting up the test')
 
     def test_is_number(self):
         self.assertFalse(asm.is_number('5s'))
         self.assertTrue(asm.is_number('128464'))
-
 
     def test_get_bin(self):
         with self.assertRaises(ValueError):
@@ -48,3 +47,31 @@ class Test_single_qubit_seqs(TestCase):
         print(self.instructions.count(0), number_of_text_nop)
         # compare
         self.assertEqual(self.instructions.count(0), number_of_text_nop)
+
+    def test_wait_zero(self):
+        zero_wait_fname = os.path.join(
+            pq.__path__[0], 'tests', 'test_data', "waitTest",
+            "waitZeroTest.qumis")
+
+        my_asm_obj = asm.Assembler(zero_wait_fname)
+        my_instructions = my_asm_obj.convert_to_instructions()
+
+        # my_instructions should corresponds to the following instructions:
+        # wait 5
+        # wait 3
+        # wait  1000
+        # trigger 0000001 1000
+        # beq r0, r0, EndOfFileLoop
+        # So the 'wait 0' line from the test file has been deleted.
+        # This is represented by the array below
+        self.assertEqual(my_instructions, [3229614085, 3229614083, 3229615080,
+                                           2692875240, 302022653])
+
+    def test_wait_negative(self):
+        neg_wait_fname = os.path.join(
+            pq.__path__[0], 'tests', 'test_data', "waitTest",
+            "waitNegativeTest.qumis")
+
+        my_asm_obj = asm.Assembler(neg_wait_fname)
+        with self.assertRaises(ValueError):
+            my_instructions = my_asm_obj.convert_to_instructions()


### PR DESCRIPTION
Assembler now ignores 'wait 0' instructions and raises a ValueError for wait instructions with negative parameter.
Added test cases with 'wait 0' and negative wait instructions.

This closes #163 . Still needs to be tested on hardware 