### PR TITLE
Two qubit sequences

### DIFF
--- a/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
+++ b/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
@@ -47,7 +47,7 @@ def two_qubit_off_on(q0, q1, RO_target='all'):
 def two_qubit_tomo_cardinal(cardinal,
                             q0,
                             q1,
-                            RO_target):
+                            RO_target='all'):
     '''
     Cardinal tomography for two qubits.
 

--- a/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
+++ b/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
@@ -1,0 +1,166 @@
+from pycqed.utilities.general import mopen
+from os.path import join, dirname
+
+base_qasm_path = join(dirname(__file__), 'qasm_files')
+
+
+def two_qubit_off_on(q0, q1, RO_target='all'):
+    '''
+    off_on sequence on two qubits.
+
+    Args:
+        q0, q1      (str) : target qubits for the sequence
+        RO_target   (str) : target for the RO, can be a qubit name or 'all'
+    '''
+    filename = join(base_qasm_path, 'two_qubit_off_on.qasm')
+    qasm_file = mopen(filename, mode='w')
+    qasm_file.writelines('qubit {} \nqubit {} \n'.format(q0, q1))
+
+    # off - off
+    qasm_file.writelines('\ninit_all\n')
+    qasm_file.writelines('I {}\n'.format(q0))
+    qasm_file.writelines('I {}\n'.format(q1))
+    qasm_file.writelines('RO {}  \n'.format(RO_target))
+
+    # on - off
+    qasm_file.writelines('\ninit_all\n')
+    qasm_file.writelines('X180 {}\n'.format(q0))
+    qasm_file.writelines('I {}\n'.format(q1))
+    qasm_file.writelines('RO {}  \n'.format(RO_target))
+
+    # off - on
+    qasm_file.writelines('\ninit_all\n')
+    qasm_file.writelines('I {}\n'.format(q0))
+    qasm_file.writelines('X180 {}\n'.format(q1))
+    qasm_file.writelines('RO {}  \n'.format(RO_target))
+
+    # on - on
+    qasm_file.writelines('\ninit_all\n')
+    qasm_file.writelines('X180 {}\n'.format(q0))
+    qasm_file.writelines('X180 {}\n'.format(q1))
+    qasm_file.writelines('RO {}  \n'.format(RO_target))
+
+    qasm_file.close()
+    return qasm_file
+
+
+def two_qubit_tomo_cardinal(cardinal,
+                            q0,
+                            q1,
+                            RO_target,
+                            timings_dict,
+                            verbose=False):
+    # TODO: docstring
+    tomo_pulses = ['I ', 'X180 ', 'Y90 ', 'mY90 ', 'X90 ', 'mX90 ']
+    for tp in tomo_pulses:
+        tomo_list_q0 = [tp + q0]
+        tomo_list_q1 = [tp + q1]
+
+    prep_pulse_q0 = tomo_list_q0[int(cardinal % len(tomo_list_q0))]
+    prep_pulse_q1 = tomo_list_q1[int(cardinal % len(tomo_list_q1))]
+
+    filename = join(base_qasm_path, 'two_qubit_tomo_cardinal.qasm')
+    qasm_file = mopen(filename, mode='w')
+    qasm_file.writelines('qubit {} \nqubit {} \n'.format(q0, q1))
+
+    for p_q0 in tomo_list_q0:
+        for p_q1 in tomo_list_q1:
+            qasm_file.writelines('\ninit_all\n')
+            qasm_file.writelines(prep_pulse_q0 + '\n')
+
+
+def two_qubit_AllXY(q0, q1, RO_target='all',
+                    sequence_type='sequential',
+                    replace_q1_pulses_X180=False,
+                    double_points=False):
+    """
+    AllXY sequence on two qubits.
+    Has the option of replacing pulses on q1 with pi pulses
+
+    Args:
+        q0, q1         (str) : target qubits for the sequence
+        RO_target      (str) : target for the RO, can be a qubit name or 'all'
+        sequence_type  (str) : sequential | interleaved | simultaneous | sandwiched
+                              q0|q0|q1|q1   q0|q1|q0|q1   q01|q01      q1|q0|q0|q1
+                            N.B.!  simultaneous is currently not possible!
+            describes the order of the AllXY pulses
+        replace_q1_pulses_X180 (bool) : if True replaces all pulses on q1 with
+            X180 pulses.
+
+        double_points (bool) : if True measures each point in the AllXY twice
+    """
+
+    pulse_combinations = [['I', 'I'], ['X180', 'X180'], ['Y180', 'Y180'],
+                          ['X180', 'Y180'], ['Y180', 'X180'],
+                          ['X90', 'I'], ['Y90', 'I'], ['X90', 'Y90'],
+                          ['Y90', 'X90'], ['X90', 'Y180'], ['Y90', 'X180'],
+                          ['X180', 'Y90'], ['Y180', 'X90'], ['X90', 'X180'],
+                          ['X180', 'X90'], ['Y90', 'Y180'], ['Y180', 'Y90'],
+                          ['X180', 'I'], ['Y180', 'I'], ['X90', 'X90'],
+                          ['Y90', 'Y90']]
+    if double_points:
+        pulse_combinations = [val for val in pulse_combinations
+                              for _ in (0, 1)]
+    filename = join(base_qasm_path, 'two_qubit_AllXY.qasm')
+    qasm_file = mopen(filename, mode='w')
+    qasm_file.writelines('qubit {} \nqubit {} \n'.format(q0, q1))
+
+    if sequence_type == 'simultaneous':
+        raise NotImplementedError('Simultaneous readout not implemented.')
+
+    if replace_q1_pulses_X180:
+        for pulse_comb in pulse_combinations:
+            qasm_file.writelines('\ninit_all\n')
+            if sequence_type == 'interleaved':
+                qasm_file.writelines('{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format('X180', q1) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format('X180', q1))
+            elif sequence_type == 'sandwiched':
+                qasm_file.writelines('{} {}\n'.format('X180', q1) +
+                                     '{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format('X180', q1))
+            elif sequence_type == 'sequential':
+                qasm_file.writelines('{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format('X180', q1) +
+                                     '{} {}\n'.format('X180', q1))
+            elif sequence_type == 'simultaneous':
+                # FIXME: Not implemented yet.
+                pass
+            else:
+                raise ValueError("sequence_type {} ".format(sequence_type) +
+                                 "['interleaved', 'simultaneous', " +
+                                 "'sequential', 'sandwiched']")
+            qasm_file.writelines('RO {}  \n'.format(RO_target))
+    else:
+        for pulse_comb in pulse_combinations:
+            qasm_file.writelines('\ninit_all\n')
+            if sequence_type == 'interleaved':
+                qasm_file.writelines('{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format(pulse_comb[0], q1) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q1))
+            elif sequence_type == 'sandwiched':
+                qasm_file.writelines('{} {}\n'.format(pulse_comb[0], q1) +
+                                     '{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q1))
+            elif sequence_type == 'sequential':
+                qasm_file.writelines('{} {}\n'.format(pulse_comb[0], q0) +
+                                     '{} {}\n'.format(pulse_comb[1], q0) +
+                                     '{} {}\n'.format(pulse_comb[0], q1) +
+                                     '{} {}\n'.format(pulse_comb[1], q1))
+            elif sequence_type == 'simultaneous':
+                # FIXME: Not implemented yet.
+                pass
+            else:
+                raise ValueError("sequence_type {} ".format(sequence_type) +
+                                 "['interleaved', 'simultaneous', " +
+                                 "'sequential', 'sandwiched']")
+            qasm_file.writelines('RO {}  \n'.format(RO_target))
+
+    qasm_file.close()
+
+    return qasm_file

--- a/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
+++ b/pycqed/measurement/waveform_control_CC/multi_qubit_qasm_seqs.py
@@ -57,9 +57,11 @@ def two_qubit_tomo_cardinal(cardinal,
         RO_target       (str) : target for the RO, can be a qubit name or 'all'
     '''
     tomo_pulses = ['I ', 'X180 ', 'Y90 ', 'mY90 ', 'X90 ', 'mX90 ']
+    tomo_list_q0 = []
+    tomo_list_q1 = []
     for tp in tomo_pulses:
-        tomo_list_q0 = [tp + q0 + '\n']
-        tomo_list_q1 = [tp + q1 + '\n']
+        tomo_list_q0 += [tp + q0 + '\n']
+        tomo_list_q1 += [tp + q1 + '\n']
 
     prep_index_q0 = int(cardinal % len(tomo_list_q0))
     prep_index_q1 = int(((cardinal - prep_index_q0) / len(tomo_list_q0) %

--- a/pycqed/tests/test_qasm_compiler.py
+++ b/pycqed/tests/test_qasm_compiler.py
@@ -217,6 +217,64 @@ class Test_single_qubit_seqs(TestCase):
         instructions = asm.convert_to_instructions()
 
 
+class Test_multi_qubit_seqs(TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.qubits = ['q0', 'q1']
+        self.times = np.linspace(20e-9, 50e-6, 61)
+        # a sample operation dictionary for testing
+        self.operation_dict = {}
+        for q in self.qubits:
+            self.operation_dict['init_all'] = {'instruction': 'WaitReg r0 \n'}
+            self.operation_dict['X180 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 1000000, 2 \n'}
+            self.operation_dict['X90 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+            self.operation_dict['Y180 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+            self.operation_dict['Y90 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+
+            self.operation_dict['mX180 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 1000000, 2 \n'}
+            self.operation_dict['mX90 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+            self.operation_dict['mY180 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+            self.operation_dict['mY90 {}'.format(q)] = {
+                'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
+
+            # FIXME: It should be possible to translate 'I' to 'wait for some
+            # time', which it is not when it is translated to an empty string
+            # like this.
+            self.operation_dict['I {}'.format(q)] = {
+                'duration': None, 'instruction': ''}
+            self.operation_dict['RO {}'.format(q)] = {
+                'duration': 8, 'instruction': 'Trigger 0010000, 2 \n'}
+        self.operation_dict['RO all'] = {
+            'duration': 8, 'instruction': 'Trigger 0010000, 2 \n'}
+
+    def test_two_qubit_off_on(self):
+        qasm_file = mq_qasm.two_qubit_off_on(self.qubits[0], self.qubits[1])
+        asm_file = qta.qasm_to_asm(qasm_file.name, self.operation_dict)
+        asm = Assembler.Assembler(asm_file.name)
+        asm.convert_to_instructions()
+
+    def test_two_qubit_tomo_cardinal(self):
+        qasm_file = mq_qasm.two_qubit_tomo_cardinal(1, self.qubits[0],
+                                                    self.qubits[1])
+        asm_file = qta.qasm_to_asm(qasm_file.name, self.operation_dict)
+        asm = Assembler.Assembler(asm_file.name)
+        asm.convert_to_instructions()
+
+    def test_two_qubit_AllXY(self):
+        qasm_file = mq_qasm.two_qubit_AllXY(self.qubits[0], self.qubits[1])
+        asm_file = qta.qasm_to_asm(qasm_file.name, self.operation_dict)
+        asm = Assembler.Assembler(asm_file.name)
+        asm.convert_to_instructions()
+
+
 class Test_qasm_to_asm(TestCase):
 
     @classmethod
@@ -314,58 +372,6 @@ class Test_qasm_to_asm(TestCase):
             qta.qasm_to_asm(qasm_file.name, self.operation_dict)
 
 
-class Test_multi_qubit_seqs(TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        self.qubits = ['q0', 'q1']
-        self.times = np.linspace(20e-9, 50e-6, 61)
-        # a sample operation dictionary for testing
-        self.operation_dict = {}
-        for q in self.qubits:
-            self.operation_dict['init_all'] = {'instruction': 'WaitReg r0 \n'}
-            self.operation_dict['X180 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 1000000, 2 \n'}
-            self.operation_dict['X90 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-            self.operation_dict['Y180 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-            self.operation_dict['Y90 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-
-            self.operation_dict['mX180 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 1000000, 2 \n'}
-            self.operation_dict['mX90 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-            self.operation_dict['mY180 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-            self.operation_dict['mY90 {}'.format(q)] = {
-                    'duration': 2, 'instruction': 'Trigger 0100000, 2 \n'}
-
-            # FIXME: It should be possible to translate 'I' to 'wait for some
-            # time', which it is not when it is translated to an empty string
-            # like this.
-            self.operation_dict['I {}'.format(q)] = {
-                    'duration': None, 'instruction': ''}
-            self.operation_dict['RO {}'.format(q)] = {
-                    'duration': 8, 'instruction': 'Trigger 0010000, 2 \n'}
-        self.operation_dict['RO all'] = {
-                'duration': 8, 'instruction': 'Trigger 0010000, 2 \n'}
-
-    def test_two_qubit_off_on(self):
-        qasm_file = mq_qasm.two_qubit_off_on(self.qubits[0], self.qubits[1])
-        asm_file = qta.qasm_to_asm(qasm_file.name, self.operation_dict)
-        asm = Assembler.Assembler(asm_file.name)
-        instruction = asm.convert_to_instructions()
-
-    def test_two_qubit_tomo_cardinal(self):
-        qasm_file = mq_qasm.two_qubit_tomo_cardinal(1, self.qubits[0],
-                                                    self.qubits[1])
-        asm_file = qta.qasm_to_asm(qasm_file.name, self.operation_dict)
-        asm = Assembler.Assembler(asm_file.name)
-        instruction = asm.convert_to_instructions()
-
-
 class Test_qasm_waveform_management(TestCase):
 
     """
@@ -415,8 +421,8 @@ class Test_qasm_waveform_management(TestCase):
                          'prepare_function_kwargs': None},
             'X180 {}'.format(self.qubit_name): {
                 'duration': 2, 'instruction': 'Trigger 1000000, 2 \n',
-                             'prepare_function': 'mock_control_pulse_prepare',
-                             'prepare_function_kwargs': {'test': 0}},
+                'prepare_function': 'mock_control_pulse_prepare',
+                'prepare_function_kwargs': {'test': 0}},
             'Y180 {}'.format(self.qubit_name): {
                 'duration': 2, 'instruction': 'Trigger 0100000, 2 \n',
                 'prepare_function': 'mock_control_pulse_prepare',
@@ -545,10 +551,12 @@ def valid_operation_dictionary(operation_dict):
 
 
 class Capturing(list):
+
     def __enter__(self):
         self._stdout = sys.stdout
         sys.stdout = self._stringio = StringIO()
         return self
+
     def __exit__(self, *args):
         self.extend(self._stringio.getvalue().splitlines())
         sys.stdout = self._stdout


### PR DESCRIPTION
Added functions to write QASM files for two qubit sequences.
Resolves #175.
Includes standard tests for the added functions.