### PR TITLE
Enh/#176/unit aware label

### DIFF
--- a/pycqed/analysis/tools/plotting.py
+++ b/pycqed/analysis/tools/plotting.py
@@ -3,7 +3,9 @@ Currently empty should contain the plotting tools portion of the
 analysis toolbox
 '''
 import numpy as np
-from pyqtgraph.units import SI_PREFIXES, UNITS as SI_UNITS
+
+SI_PREFIXES = 'yzafpnum kMGTPEZY'
+SI_UNITS = 'm,s,g,W,J,V,A,F,T,Hz,Ohm,S,N,C,px,b,B'.split(',')
 
 
 def set_xlabel(axis, label, unit=None, **kw):
@@ -76,7 +78,7 @@ def SI_prefix_and_scale_factor(val, unit=None):
 
 
 def annotate_point_pair(ax, text, xy_start, xy_end, xycoords='data',
-                        text_offset=(-10, -5), arrowprops = None, **kw):
+                        text_offset=(-10, -5), arrowprops=None, **kw):
     '''
     Annotates two points by connecting them with an arrow.
     The annotation text is placed near the center of the arrow.
@@ -97,9 +99,9 @@ def annotate_point_pair(ax, text, xy_start, xy_end, xycoords='data',
     text_angle = arrow_angle - 0.5*np.pi
 
     ax.annotate(
-            '', xy=xy_end, xycoords=xycoords,
-            xytext=xy_start, textcoords=xycoords,
-            arrowprops=arrowprops, **kw)
+        '', xy=xy_end, xycoords=xycoords,
+        xytext=xy_start, textcoords=xycoords,
+        arrowprops=arrowprops, **kw)
 
     label = ax.annotate(
         text,

--- a/pycqed/analysis/tools/plotting.py
+++ b/pycqed/analysis/tools/plotting.py
@@ -54,8 +54,14 @@ def set_ylabel(axis, label, unit=None, **kw):
 
 def SI_prefix_and_scale_factor(val, unit=None):
     """
-    Takes in a value and unit and if applicable returns the proper SI prefix
-    and prefix power
+    Takes in a value and unit and if applicable returns the proper
+    scale factor and SI prefix.
+    Args:
+        val (float) : the value
+        unit (str)  : the unit of the value
+    returns:
+        scale_factor (float) : scale_factor needed to convert value
+        unit (str)           : unit including the prefix
     """
     validtypes = (float, int, np.integer, np.floating)
     if unit in SI_UNITS and isinstance(val, validtypes):

--- a/pycqed/analysis/tools/plotting.py
+++ b/pycqed/analysis/tools/plotting.py
@@ -17,11 +17,14 @@ def set_xlabel(axis, label, unit=None, **kw):
         **kw : keyword argument to be passed to matplotlib.set_xlabel
 
     """
-    xticks = axis.get_xticks()
-    scale_factor, unit = SI_prefix_and_scale_factor(
-        val=max(abs(xticks)), unit=unit)
-    axis.set_xticklabels(xticks*scale_factor)
-    axis.set_xlabel(label+' ({})'.format(unit), **kw)
+    if unit is not None:
+        xticks = axis.get_xticks()
+        scale_factor, unit = SI_prefix_and_scale_factor(
+            val=max(abs(xticks)), unit=unit)
+        axis.set_xticklabels(xticks*scale_factor)
+        axis.set_xlabel(label+' ({})'.format(unit), **kw)
+    else:
+        axis.set_xlabel(label, **kw)
     return axis
 
 
@@ -36,11 +39,14 @@ def set_ylabel(axis, label, unit=None, **kw):
         **kw : keyword argument to be passed to matplotlib.set_ylabel
 
     """
-    yticks = axis.get_yticks()
-    scale_factor, unit = SI_prefix_and_scale_factor(
-        val=max(abs(yticks)), unit=unit)
-    axis.set_yticklabels(yticks*scale_factor)
-    axis.set_ylabel(label+' ({})'.format(unit), **kw)
+    if unit is not None:
+        yticks = axis.get_yticks()
+        scale_factor, unit = SI_prefix_and_scale_factor(
+            val=max(abs(yticks)), unit=unit)
+        axis.set_yticklabels(yticks*scale_factor)
+        axis.set_ylabel(label+' ({})'.format(unit), **kw)
+    else:
+        axis.set_ylabel(label, **kw)
     return axis
 
 

--- a/pycqed/analysis/tools/plotting.py
+++ b/pycqed/analysis/tools/plotting.py
@@ -3,6 +3,70 @@ Currently empty should contain the plotting tools portion of the
 analysis toolbox
 '''
 import numpy as np
+from pyqtgraph.units import SI_PREFIXES, UNITS as SI_UNITS
+
+
+def set_xlabel(axis, label, unit=None, **kw):
+    """
+    Takes in an axis object and add a unit aware label to it.
+
+    Args:
+        axis: matplotlib axis object to set label on
+        label: the desired label
+        unit:  the unit
+        **kw : keyword argument to be passed to matplotlib.set_xlabel
+
+    """
+    xticks = axis.get_xticks()
+    scale_factor, unit = SI_prefix_and_scale_factor(
+        val=max(abs(xticks)), unit=unit)
+    axis.set_xticklabels(xticks*scale_factor)
+    axis.set_xlabel(label+' ({})'.format(unit), **kw)
+    return axis
+
+
+def set_ylabel(axis, label, unit=None, **kw):
+    """
+    Takes in an axis object and add a unit aware label to it.
+
+    Args:
+        axis: matplotlib axis object to set label on
+        label: the desired label
+        unit:  the unit
+        **kw : keyword argument to be passed to matplotlib.set_ylabel
+
+    """
+    yticks = axis.get_yticks()
+    scale_factor, unit = SI_prefix_and_scale_factor(
+        val=max(abs(yticks)), unit=unit)
+    axis.set_yticklabels(yticks*scale_factor)
+    axis.set_ylabel(label+' ({})'.format(unit), **kw)
+    return axis
+
+
+def SI_prefix_and_scale_factor(val, unit=None):
+    """
+    Takes in a value and unit and if applicable returns the proper SI prefix
+    and prefix power
+    """
+    validtypes = (float, int, np.integer, np.floating)
+    if unit in SI_UNITS and isinstance(val, validtypes):
+        if val == 0:
+            prefix_power = 0
+        else:
+            # The defined prefixes go down to -24 but this is below
+            # the numerical precision of python
+            prefix_power = np.clip(-15, (np.log10(abs(val))//3 * 3), 24)
+        # Determine SI prefix, number 8 corresponds to no prefix
+        SI_prefix_idx = int(prefix_power/3 + 8)
+        prefix = SI_PREFIXES[SI_prefix_idx]
+        # Convert the unit
+        scale_factor = 10**-prefix_power
+        unit = prefix+unit
+    else:
+        scale_factor = 1
+
+    return scale_factor, unit
 
 
 def annotate_point_pair(ax, text, xy_start, xy_end, xycoords='data',

--- a/pycqed/tests/test_unit_conversions.py
+++ b/pycqed/tests/test_unit_conversions.py
@@ -1,0 +1,29 @@
+import unittest
+import numpy as np
+
+from pycqed.analysis.tools.plotting import SI_prefix_and_scale_factor
+
+
+class Test_SI_prefix_scale_factor(unittest.TestCase):
+
+    def test_non_SI(self):
+        unit = 'arb.unit.'
+        scale_factor, post_unit = SI_prefix_and_scale_factor(val=5, unit=unit)
+        self.assertEqual(scale_factor, 1)
+        self.assertEqual(unit, post_unit)
+
+    def test_SI_scale_factors(self):
+        unit = 'V'
+        scale_factor, post_unit = SI_prefix_and_scale_factor(val=5, unit=unit)
+        self.assertEqual(scale_factor, 1)
+        self.assertEqual(' '+unit, post_unit)
+
+        scale_factor, post_unit = SI_prefix_and_scale_factor(val=5000,
+                                                             unit=unit)
+        self.assertEqual(scale_factor, 1/1000)
+        self.assertEqual('k'+unit, post_unit)
+
+        scale_factor, post_unit = SI_prefix_and_scale_factor(val=0.05,
+                                                             unit=unit)
+        self.assertEqual(scale_factor, 1000)
+        self.assertEqual('m'+unit, post_unit)

--- a/pycqed/tests/test_unit_conversions.py
+++ b/pycqed/tests/test_unit_conversions.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy as np
-
+import matplotlib.pyplot as plt
 from pycqed.analysis.tools.plotting import SI_prefix_and_scale_factor
+from pycqed.analysis.tools.plotting import set_xlabel, set_ylabel
 
 
 class Test_SI_prefix_scale_factor(unittest.TestCase):
@@ -27,3 +28,27 @@ class Test_SI_prefix_scale_factor(unittest.TestCase):
                                                              unit=unit)
         self.assertEqual(scale_factor, 1000)
         self.assertEqual('m'+unit, post_unit)
+
+
+class test_SI_unit_aware_labels(unittest.TestCase):
+
+    def test_label_scaling(self):
+        f, ax = plt.subplots()
+        x = np.linspace(-6, 6, 101)
+        y = np.cos(x)
+        ax.plot(x*1000, y/1e5)
+
+        set_xlabel(ax, 'Distance', 'm')
+        set_ylabel(ax, 'Amplitude', 'V')
+
+        xticks = ax.get_xticks()
+        xtick_labels = ax.get_xticklabels()
+        xtick_label_vals = [float(xl.get_text()) for xl in xtick_labels]
+        for xt, xl in zip(xticks, xtick_label_vals):
+            self.assertEqual(xt/1000, xl)
+
+        yticks = ax.get_yticks()
+        ytick_labels = ax.get_yticklabels()
+        ytick_label_vals = [float(yl.get_text()) for yl in ytick_labels]
+        for yt, yl in zip(yticks, ytick_label_vals):
+            self.assertAlmostEqual(yt*1e6, yl)

--- a/pycqed/tests/test_unit_conversions.py
+++ b/pycqed/tests/test_unit_conversions.py
@@ -33,6 +33,10 @@ class Test_SI_prefix_scale_factor(unittest.TestCase):
 class test_SI_unit_aware_labels(unittest.TestCase):
 
     def test_label_scaling(self):
+        """
+        This test creates a dummy plot and checks if the tick labels are
+        rescaled correctly
+        """
         f, ax = plt.subplots()
         x = np.linspace(-6, 6, 101)
         y = np.cos(x)
@@ -45,7 +49,7 @@ class test_SI_unit_aware_labels(unittest.TestCase):
         xtick_labels = ax.get_xticklabels()
         xtick_label_vals = [float(xl.get_text()) for xl in xtick_labels]
         for xt, xl in zip(xticks, xtick_label_vals):
-            self.assertEqual(xt/1000, xl)
+            self.assertEqual(xt*1e-3, xl)
 
         yticks = ax.get_yticks()
         ytick_labels = ax.get_yticklabels()


### PR DESCRIPTION
@fluthi @NielsBultink @elrama- 
A unit aware way of setting xlabel and ylabel, use this instead of the matplotlib defaul ax.set_xlabel/ax.set_ylabel 

The following snippet should serve as a minimal example of how it works. 

```python 
%matplotlib inline
import matplotlib.pyplot as plt
import numpy as np
from imp import reload
from pycqed.analysis.tools import plotting as pl


f, ax = plt.subplots()
x = np.linspace(-6, 6, 101)
y=np.cos(x)
ax.plot(x/1000, y*1e3)

pl.set_xlabel(ax, 'Time', 's')
pl.set_ylabel(ax, 'Distance', 'm')
```

And the resulting figure. 
![screenshot 2017-04-19 22 59 03](https://cloud.githubusercontent.com/assets/6142932/25201945/d8701144-2553-11e7-9c4e-a3248f3bbd49.png)


This closes #176. 
