### PR TITLE
Fix for bug with negative frequencies in fit

### DIFF
--- a/pycqed/analysis/fitting_models.py
+++ b/pycqed/analysis/fitting_models.py
@@ -388,7 +388,7 @@ def Cos_guess(model, data, t):
 
     # Use absolute value of complex valued spectrum
     abs_w = np.abs(w)
-    freq_guess = f[abs_w == max(abs_w)][0]
+    freq_guess = abs(f[abs_w == max(abs_w)][0])
     ph_guess = (-2*np.pi*t[data == max(data)]*freq_guess)[0]
     # the condition data == max(data) can have several solutions
     #               (for example when discretization is visible)
@@ -400,6 +400,7 @@ def Cos_guess(model, data, t):
                                phase=ph_guess,
                                offset=offs_guess)
     params['amplitude'].min = 0  # Ensures positive amp
+    params['frequency'].min = 0
 
     return params
 


### PR DESCRIPTION
The recent changes that improved the Rabi analysis seems to have introduced a new bug. It can happen that the frequency is chosen to be negative, leading to an error in the estimation of the phase. 

This is of no consequence when only considering a single curve but leads to problems when calculating the phase difference between two oscillations (as is the case in CZ tuning). 

@lciorciaro @NielsBultink @fluthi could one of you take a look at the one line I changed? I'm asking you guys as you were involved in this change. 