### PR TITLE
Removed circular dependency in meas. analysis

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -30,7 +30,6 @@ from pycqed.analysis import composite_analysis as ca
 
 try:
     import qutip as qtp
-    from pycqed.analysis.tomography import Tomo_Multiplexed
 except ImportError as e:
     if str(e).find('qutip') >= 0:
         logging.warning('Could not import qutip')


### PR DESCRIPTION
tomography.py imports measurement_anlaysis.py, which imports Tomo_Multiplexed from tomography. Since Tomo_Multiplexed is not used anywhere it can be safely removed to resolve the circular dependency.