### PR TITLE
Hotfix for Function_Detector enabling use of Instrument in msmt_kw

### DIFF
--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -10,7 +10,7 @@ from pycqed.analysis.fit_toolbox import functions as fn
 from pycqed.measurement.waveform_control import pulse
 from pycqed.measurement.waveform_control import element
 from pycqed.measurement.waveform_control import sequence
-
+from qcodes.instrument.parameter import _BaseParameter
 from pycqed.instrument_drivers.virtual_instruments.pyqx import qasm_loader as ql
 
 
@@ -845,7 +845,7 @@ class Function_Detector(Soft_Detector):
         # If an entry has a get method that will be used to set the value.
         # This makes parameters work in this context.
         for key, item in self.msmt_kw.items():
-            if hasattr(item, 'get'):
+            if isinstance(item, _BaseParameter):
                 value = item.get()
             else:
                 value = item


### PR DESCRIPTION
Until now, when using an Instrument in msmt_kw of a Function_Detector, an error was raised because Instruments do have a get() function like parameters, but it has a different call signature and is indeed not what the Function_Detector should call.
This small change fixes this issue