### PR TITLE
Fixed problems with 'resonator fit'

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -487,6 +487,33 @@ class MeasurementAnalysis(object):
 
         return
 
+    def plot_dB_from_linear(self, x, lin_amp, fig, ax, show=False, marker='.', **kw):
+        '''
+        Plot linear data in dB.
+        This is usefull for measurements performed with VNA and Homodyne
+
+        Author: Stefano Poletto
+        Date: May 5, 2017
+        '''
+        save = kw.pop('save', False)
+        self.plot_title = kw.pop('plot_title',
+                                 textwrap.fill(self.timestamp_string + '_' +
+                                               self.measurementstring, 40))
+
+        xlabel = 'Freq'
+        ylabel = 'Transmission (dB)'
+        ax.set_title(self.plot_title)
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        y_dB = 20*np.log10(lin_amp)
+        ax.plot(x, y_dB, marker)
+        if show:
+            plt.show()
+        if save:
+            self.save_fig(fig, xlabel=xlabel, ylabel=ylabel, **kw)
+
+        return
+
     def get_naming_and_values_2D(self):
         '''
         This should also be adjusted for 2D.
@@ -1166,12 +1193,14 @@ class Rabi_Analysis(TD_Analysis):
 
             fine_fit = self.fit_res[i].model.func(
                 x_fine, **self.fit_res[i].best_values)
-            #adding the fitted amp180
+            # adding the fitted amp180
             if 'period' in self.fit_res[i].params.keys():
-                label='amp180 = {:.3e}'.format(abs(self.fit_res[i].params['period'].value)/2)
+                label = 'amp180 = {:.3e}'.format(
+                    abs(self.fit_res[i].params['period'].value)/2)
             else:
-                label='amp180 = {:.3e}'.format(abs(self.fit_res[i].params['x0'].value))
-            self.axs[i].plot(x_fine, fine_fit,label=label )
+                label = 'amp180 = {:.3e}'.format(
+                    abs(self.fit_res[i].params['x0'].value))
+            self.axs[i].plot(x_fine, fine_fit, label=label)
             ymin = min(self.measured_values[i])
             ymax = max(self.measured_values[i])
             yspan = ymax-ymin
@@ -1193,11 +1222,11 @@ class Rabi_Analysis(TD_Analysis):
         # We make an initial guess of the Rabi period using both quadratures
         data = np.sqrt(self.measured_values[0]**2+self.measured_values[1]**2)
         params = model.guess(model, data=data,
-                                 t=self.sweep_points)
+                             t=self.sweep_points)
         fit_res = fit_mods.CosModel.fit(
-                data=data,
-                t=self.sweep_points,
-                params=params)
+            data=data,
+            t=self.sweep_points,
+            params=params)
         freq_guess = fit_res.values['frequency']
         for i in [0, 1]:
             params = model.guess(model, data=self.measured_values[i],
@@ -3666,7 +3695,7 @@ class Homodyne_Analysis(MeasurementAnalysis):
             # NB! Expressions are broken in lmfit for python 3.5 this has
             # been fixed in the lmfit repository but is not yet released
             # the newest upgrade to lmfit should fix this (MAR 18-2-2016)
-            HangerModel.set_param_hint('Qi', expr='1./(1./Q-1./Qe*cos(theta))',
+            HangerModel.set_param_hint('Qi', expr='abs(1./(1./Q-1./Qe*cos(theta)))',
                                        vary=False)
             HangerModel.set_param_hint('Qc', expr='Qe/cos(theta)', vary=False)
             HangerModel.set_param_hint('theta', value=0, min=-np.pi/2,
@@ -3772,7 +3801,7 @@ class Homodyne_Analysis(MeasurementAnalysis):
 
         fig, ax = self.default_ax()
 
-        if 'hanger' in fitting_model:
+        if ('hanger' in fitting_model) or ('complex' in fitting_model):
             textstr = '$f_{\mathrm{center}}$ = %.4f $\pm$ (%.3g) GHz' % (
                 fit_res.params['f0'].value, fit_res.params['f0'].stderr) + '\n' \
                 '$Qc$ = %.1f $\pm$ (%.1f)' % (fit_res.params['Qc'].value, fit_res.params['Qc'].stderr) + '\n' \
@@ -3838,7 +3867,7 @@ class Homodyne_Analysis(MeasurementAnalysis):
         else:
             ax.plot(self.sweep_points, fit_res.best_fit, 'r-')
             f0 = self.fit_results.values['f0']
-            plt.plot(f0, fit_res.eval(f=f0), 'o', ms=8)
+            plt.plot(f0*1e9, fit_res.eval(f=f0*1e9), 'o', ms=8)
 
             # save figure
             self.save_fig(fig, xlabel=self.xlabel, ylabel='Mag', **kw)
@@ -3851,7 +3880,37 @@ class Homodyne_Analysis(MeasurementAnalysis):
         return fit_res
 
 
+################
+# VNA analysis #
+################
+class VNA_Analysis(MeasurementAnalysis):
+    '''
+    Nice to use with all measurements performed with the VNA.
+    '''
+
+    def __init__(self, label='VNA', **kw):
+        kw['label'] = label
+        kw['h5mode'] = 'r+'
+        super().__init__(**kw)
+
+    def run_default_analysis(self, **kw):
+        super(self.__class__, self).run_default_analysis(
+            close_file=False, **kw)
+
+        # prepare figure in log scale
+        data_amp = self.measured_values[0]
+
+        fig, ax = self.default_ax()
+        self.plot_dB_from_linear(x=self.sweep_points,
+                                 lin_amp=data_amp,
+                                 fig=fig, ax=ax,
+                                 save=False)
+
+        self.save_fig(fig, figname='dB_plot', **kw)
+
+
 class Acquisition_Delay_Analysis(MeasurementAnalysis):
+
     def __init__(self, label='AD', **kw):
         kw['label'] = label
         kw['h5mode'] = 'r+'
@@ -5551,9 +5610,9 @@ class AvoidedCrossingAnalysis(MeasurementAnalysis):
         flux = self.Y[:, 0]
         peaks_low, peaks_high = self.find_peaks()
         self.f, self.ax = self.make_unfiltered_figure(peaks_low, peaks_high,
-                                    transpose=transpose, cmap=cmap,
-                                    add_title=add_title,
-                                    xlabel=xlabel, ylabel=ylabel)
+                                                      transpose=transpose, cmap=cmap,
+                                                      add_title=add_title,
+                                                      xlabel=xlabel, ylabel=ylabel)
 
         filtered_dat = self.filter_data(flux, peaks_low, peaks_high,
                                         a=filt_func_a, x0=filt_func_x0,
@@ -5565,10 +5624,10 @@ class AvoidedCrossingAnalysis(MeasurementAnalysis):
             filter_func = filtered_dat
 
         self.f, self.ax = self.make_filtered_figure(filt_flux_low, filt_flux_high,
-                                  filt_peaks_low, filt_peaks_high, filter_func,
-                                  add_title=add_title,
-                                  transpose=transpose, cmap=cmap,
-                                  xlabel=xlabel, ylabel=ylabel)
+                                                    filt_peaks_low, filt_peaks_high, filter_func,
+                                                    add_title=add_title,
+                                                    transpose=transpose, cmap=cmap,
+                                                    xlabel=xlabel, ylabel=ylabel)
         if break_before_fitting:
             return
         self.fit_res = self.fit_avoided_crossing(
@@ -5579,13 +5638,12 @@ class AvoidedCrossingAnalysis(MeasurementAnalysis):
         self.add_analysis_datagroup_to_file()
         self.save_fitted_parameters(self.fit_res, var_name='avoided crossing')
         self.f, self.ax = self.make_fit_figure(filt_flux_low, filt_flux_high,
-                             filt_peaks_low, filt_peaks_high,
-                             add_title=add_title,
-                             fit_res=self.fit_res,
-                             coupling_label=coupling_label,
-                             transpose=transpose, cmap=cmap,
-                             xlabel=xlabel, ylabel=ylabel)
-
+                                               filt_peaks_low, filt_peaks_high,
+                                               add_title=add_title,
+                                               fit_res=self.fit_res,
+                                               coupling_label=coupling_label,
+                                               transpose=transpose, cmap=cmap,
+                                               xlabel=xlabel, ylabel=ylabel)
 
     def run_default_analysis(self, **kw):
         # I'm doing this in the init in this function


### PR DESCRIPTION
Minor fix: the abs value of Qi is implemented in the fit function. This minor fit is necessary because of negative values returned in same cases.

Major fix: the "complex" option of the fit was not working because the 'params' were not prepared.