### PR TITLE
Move_to_dac_value function in qubit object

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -3838,7 +3838,7 @@ class Homodyne_Analysis(MeasurementAnalysis):
         else:
             ax.plot(self.sweep_points, fit_res.best_fit, 'r-')
             f0 = self.fit_results.values['f0']
-            plt.plot(f0, fit_res.eval(f=f0), 'o', ms=8)
+            plt.plot(f0*1e9, fit_res.eval(f=f0*1e9), 'o', ms=8)
 
             # save figure
             self.save_fig(fig, xlabel=self.xlabel, ylabel='Mag', **kw)
@@ -4049,11 +4049,14 @@ class Qubit_Spectroscopy_Analysis(MeasurementAnalysis):
                     data_real=self.measured_values[2],
                     data_imag=self.measured_values[3])
             except:
-                # Quick fix to make it work with pulsed spec which does not
-                # return both I,Q and, amp and phase
-                self.data_dist = a_tools.calculate_distance_ground_state(
-                    data_real=self.measured_values[0],
-                    data_imag=self.measured_values[1])
+                # Do not use distance if amplitude and phase are returned
+                self.data_dist = self.measured_values[0]
+
+                # # Quick fix to make it work with pulsed spec which does not
+                # # return both I,Q and, amp and phase
+                # self.data_dist = a_tools.calculate_distance_ground_state(
+                #     data_real=self.measured_values[0],
+                #     data_imag=self.measured_values[1])
 
             self.peaks = a_tools.peak_finder(
                 self.sweep_points, a_tools.smooth(self.data_dist))

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/Tektronix_driven_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/Tektronix_driven_transmon.py
@@ -59,7 +59,8 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
 
         self.add_parameter('AWG', parameter_class=InstrumentParameter)
 
-        self.add_parameter('heterodyne_instr', parameter_class=InstrumentParameter)
+        self.add_parameter('heterodyne_instr',
+                           parameter_class=InstrumentParameter)
 
         self.add_parameter('LutMan', parameter_class=InstrumentParameter)
         self.add_parameter('CBox', parameter_class=InstrumentParameter)
@@ -67,7 +68,6 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
 
         self.add_parameter('RF_RO_source',
                            parameter_class=InstrumentParameter)
-
 
         self.add_parameter('mod_amp_cw', label='RO modulation ampl cw',
                            unit='V', initial_value=0.5,
@@ -254,6 +254,17 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
     def set_dist_dict(self, dist_dict):
         self._dist_dict = dist_dict
 
+    def move_to_dac_value(self, dac_value):
+        '''
+        Moves the dac value defined in qubit.dac_channel to the defined value
+        and updates the qubit.dac_voltage
+        '''
+        # move IVVI
+        dac_id = 'dac%s'%(self.dac_channel())
+        self.IVVI.get_instr().set(dac_id, dac_value)
+        # store info
+        self.dac_voltage(dac_value)
+
     def prepare_for_continuous_wave(self):
         # makes sure the settings of the acquisition instrument are reloaded
         self.acquisition_instr(self.acquisition_instr())
@@ -278,7 +289,7 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
         self.heterodyne_instr.get_instr().RF_power(self.RO_power_cw())
         self.heterodyne_instr.get_instr().nr_averages(self.RO_acq_averages())
         # Turning of TD source
-        if self.td_source.get_instr() is not  None:
+        if self.td_source() is not 'None':
             self.td_source.get_instr().off()
 
         # Updating Spec source
@@ -962,25 +973,29 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
 
         self._acquisition_instr = self.find_instrument(acquisition_instr)
         if 'CBox' in acquisition_instr:
-            logging.info("setting CBox acquisition")
-            self.int_avg_det = det.CBox_integrated_average_detector(self._acquisition_instr,
-                                                                    self.AWG.get_instr(),
-                                                                    nr_averages=self.RO_acq_averages(),
-                                                                    integration_length=self.RO_acq_integration_length(
-                                                                    ),
-                                                                    normalize=True)
-            self.int_avg_det_rot = det.CBox_integrated_average_detector(self._acquisition_instr,
+            if self.AWG() != 'None':
+                logging.info("setting CBox acquisition")
+                print('starting int avg')
+                self.int_avg_det = det.CBox_integrated_average_detector(self._acquisition_instr,
                                                                         self.AWG.get_instr(),
                                                                         nr_averages=self.RO_acq_averages(),
                                                                         integration_length=self.RO_acq_integration_length(
                                                                         ),
                                                                         normalize=True)
-            self.int_log_det = det.CBox_integration_logging_det(self._acquisition_instr,
-                                                                self.AWG.get_instr(), integration_length=self.RO_acq_integration_length())
+                print('starting int avg rot')
+                self.int_avg_det_rot = det.CBox_integrated_average_detector(self._acquisition_instr,
+                                                                            self.AWG.get_instr(),
+                                                                            nr_averages=self.RO_acq_averages(),
+                                                                            integration_length=self.RO_acq_integration_length(
+                                                                            ),
+                                                                            normalize=True)
+                print('starting int log det')
+                self.int_log_det = det.CBox_integration_logging_det(self._acquisition_instr,
+                                                                    self.AWG.get_instr(), integration_length=self.RO_acq_integration_length())
 
-            self.input_average_detector = det.CBox_input_average_detector(
-                self._acquisition_instr,
-                self.AWG.get_instr(), nr_averages=self.RO_acq_averages())
+                self.input_average_detector = det.CBox_input_average_detector(
+                    self._acquisition_instr,
+                    self.AWG.get_instr(), nr_averages=self.RO_acq_averages())
 
         elif 'UHFQC' in acquisition_instr:
             logging.info("setting UHFQC acquisition")
@@ -1014,11 +1029,11 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
                 AWG=self.AWG, nr_averages=self.RO_acq_averages())
 
             self.int_avg_det = det.DDM_integrated_average_detector(
-                    DDM=self._acquisition_instr, AWG=self.AWG,
-                    channels=[self.RO_acq_weight_function_I(),
-                              self.RO_acq_weight_function_Q()],
-                    nr_averages=self.RO_acq_averages(),
-                    integration_length=self.RO_acq_integration_length())
+                DDM=self._acquisition_instr, AWG=self.AWG,
+                channels=[self.RO_acq_weight_function_I(),
+                          self.RO_acq_weight_function_Q()],
+                nr_averages=self.RO_acq_averages(),
+                integration_length=self.RO_acq_integration_length())
 
             self.int_log_det = det.DDM_integration_logging_det(
                 DDM=self._acquisition_instr, AWG=self.AWG,
@@ -1032,11 +1047,11 @@ class Tektronix_driven_transmon(CBox_driven_transmon):
                 AWG=self.AWG, nr_averages=self.RO_acq_averages())
 
             self.int_avg_det = det.DDM_integrated_average_detector(
-                    DDM=self._acquisition_instr, AWG=self.AWG,
-                    channels=[self.RO_acq_weight_function_I(),
-                              self.RO_acq_weight_function_Q()],
-                    nr_averages=self.RO_acq_averages(),
-                    integration_length=self.RO_acq_integration_length())
+                DDM=self._acquisition_instr, AWG=self.AWG,
+                channels=[self.RO_acq_weight_function_I(),
+                          self.RO_acq_weight_function_Q()],
+                nr_averages=self.RO_acq_averages(),
+                integration_length=self.RO_acq_integration_length())
 
             self.int_log_det = det.DDM_integration_logging_det(
                 DDM=self._acquisition_instr, AWG=self.AWG,


### PR DESCRIPTION
Qubit.move_to_dac_value(val)
sets the IVVI channel linked to the qubit to the 'val' specified.
Moreover, it updates the dac value parameter in the qubit object