### PR TITLE
Fixes failing spectroscopy analysis when no peaks are found

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -4133,7 +4133,7 @@ class Qubit_Spectroscopy_Analysis(MeasurementAnalysis):
             if kappa_guess == 0:
                     kappa_guess = 1 # When kappa_guess is zero, the fitting procedure fails (claims 'input has nan values')
 
-            if not peak_flag: # Cahnge the sign of amplitude_guess for dips
+            if not peak_flag: # Change the sign of amplitude_guess for dips
                 amplitude_guess*=-1.
 
             LorentzianModel = fit_mods.LorentzianModel

--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -4130,6 +4130,12 @@ class Qubit_Spectroscopy_Analysis(MeasurementAnalysis):
             amplitude_guess = np.pi * kappa_guess * \
                 abs(max(self.data_dist) - min(self.data_dist))
 
+            if kappa_guess == 0:
+                    kappa_guess = 1 # When kappa_guess is zero, the fitting procedure fails (claims 'input has nan values')
+
+            if not peak_flag: # Cahnge the sign of amplitude_guess for dips
+                amplitude_guess*=-1.
+
             LorentzianModel = fit_mods.LorentzianModel
             LorentzianModel.set_param_hint('f0',
                                            min=min(self.sweep_points),


### PR DESCRIPTION
When we didn't get a peak in the data, the analysis would crash giving the error 'input contains nan values', due to bad fitting.  When setting kappa_guess to 1 instead of 0 (which is the minimum value in the fitting procedure), we prevent the whole procedure from crashing. 