### PR TITLE
Use mu instead of u as SI prefix

### DIFF
--- a/pycqed/analysis/tools/plotting.py
+++ b/pycqed/analysis/tools/plotting.py
@@ -4,7 +4,7 @@ analysis toolbox
 '''
 import numpy as np
 
-SI_PREFIXES = 'yzafpnum kMGTPEZY'
+SI_PREFIXES = 'yzafpnμm kMGTPEZY'
 SI_UNITS = 'm,s,g,W,J,V,A,F,T,Hz,Ohm,S,N,C,px,b,B,K,Bar'.split(',')
 
 


### PR DESCRIPTION
Fixes #271.

Changes proposed in this pull request:
- replace 'u' with 'mu' in the unit conversion. This affects the set_xlabel and set_ylabel functions and the instrument monitor. 
