### PR TITLE
Replaced dac_flux_coefficient by V_per_phi0

### DIFF
--- a/pycqed/analysis/fitting_models.py
+++ b/pycqed/analysis/fitting_models.py
@@ -61,7 +61,7 @@ def TwinLorentzFunc(f, amplitude_a, amplitude_b, center_a, center_b,
 
 
 def Qubit_dac_to_freq(dac_voltage, f_max, E_c,
-                      dac_sweet_spot, V_per_phi0, dac_flux_coefficient=None,
+                      dac_sweet_spot, V_per_phi0=None, dac_flux_coefficient=None,
                       asymmetry=0):
     '''
     The cosine Arc model for uncalibrated flux for asymmetric qubit.


### PR DESCRIPTION
Changes proposed in this pull request:

For the conversion between voltage and flux in the dac-arc, the
physically meaningful constant of 'voltage per phi0' should be used; i.e. how many volts must be applied to get a flux of phi0. This is implemented here in a backwards-compatible way.