### PR TITLE
Email update when you break the test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 notifications:
-  email: false
+  email: true
 
 cache: pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 pandas
 qutip
 pyqtgraph
+pygsti


### PR DESCRIPTION
Annoying emails for everyone! 

This change makes travis send you an email when you are the one that makes a commit that breaks a test build. I also added PyGSTi as a dependency so that it can be safely used in any import statements (or potentially in future tests). 

