### PR TITLE
Improvements to measurement_analysis.py and analysis_toolbox.py.

### DIFF
--- a/pycqed/analysis/analysis_toolbox.py
+++ b/pycqed/analysis/analysis_toolbox.py
@@ -1,6 +1,5 @@
 # some convenience tools
 #
-import inspect
 import logging
 import numpy as np
 import os
@@ -437,8 +436,7 @@ def get_data_from_ma_v2(ma, param_names, numeric_params=None):
 
 def get_data_from_ma(ma, param_names, data_version=2, numeric_params=None):
     if data_version == 1:
-        data = get_data_from_ma_v1(ma, param_names,
-                                   numeric_params=numeric_params)
+        data = get_data_from_ma_v1(ma, param_names)
     elif data_version == 2:
         data = get_data_from_ma_v2(ma, param_names,
                                    numeric_params=numeric_params)
@@ -896,7 +894,6 @@ def find_second_peak(sweep_pts=None, data_dist_smooth=None,
     tallest_peak = peaks[key] #the ge freq
     tallest_peak_idx = peaks[key+'_idx']
     tallest_peak_width = peaks[key+'_width']
-    tallest_peak_val = data_dist_smooth[tallest_peak_idx]
     if verbose:
         print('Largest peak is at ',tallest_peak)
 
@@ -1165,7 +1162,7 @@ def look_for_peaks_dips(x, y_smoothed, percentile=20, window_len=11,
     threshold = background_mean + num_sigma_threshold * background_std
 
     thresholdlst = np.arange(y_smoothed.size)[y_smoothed > threshold]
-    datthreshold = y_smoothed[thresholdlst]
+    #datthreshold = y_smoothed[thresholdlst]
 
     if thresholdlst.size is 0:
         kk = 0
@@ -1240,7 +1237,7 @@ def look_for_peaks_dips(x, y_smoothed, percentile=20, window_len=11,
     threshold = background_mean - num_sigma_threshold * background_std
 
     thresholdlst = np.arange(y_smoothed.size)[y_smoothed < threshold]
-    datthreshold = y_smoothed[thresholdlst]
+    #datthreshold = y_smoothed[thresholdlst]
 
     if thresholdlst.size is 0:
         kk = 0
@@ -1510,7 +1507,7 @@ def rotate_and_normalize_data(data, cal_zero_points=None, cal_one_points=None,
         # Rotate the data
         M = calculate_rotation_matrix(I_one-I_zero, Q_one-Q_zero)
         outp = [np.asarray(elem)[0] for elem in M * trans_data]
-        [rotated_data_ch1, rotated_data_ch2] = outp
+        rotated_data_ch1 = outp[0]
 
         # Normalize the data
         one_zero_dist = np.sqrt((I_one-I_zero)**2 + (Q_one-Q_zero)**2)
@@ -1768,7 +1765,7 @@ def color_plot_slices(xvals, yvals, zvals, ax=None,
     # various plot options
     # define colormap
     cmap = kw.pop('cmap', 'viridis')
-    clim = kw.pop('clim', [None, None])
+    #clim = kw.pop('clim', [None, None])
     # normalized plot
     if normalize:
         for xx in range(len(xvals)):
@@ -1779,13 +1776,13 @@ def color_plot_slices(xvals, yvals, zvals, ax=None,
             zvals[xx] = np.log(zvals[xx])/np.log(10)
 
     # add blocks to plot
-    hold = kw.pop('hold', False)
+    #hold = kw.pop('hold', False)
     for xx in range(len(xvals)):
         tempzvals = np.array([np.append(zvals[xx], np.array(0)),
                               np.append(zvals[xx], np.array(0))]).transpose()
-        im = ax.pcolor(xvertices[xx:xx+2],
-                       yvertices[xx],
-                       tempzvals, cmap=cmap)
+        # im = ax.pcolor(xvertices[xx:xx+2],
+        #                yvertices[xx],
+        #                tempzvals, cmap=cmap)
     return ax
 
 

--- a/pycqed/analysis/fitting_models.py
+++ b/pycqed/analysis/fitting_models.py
@@ -50,15 +50,12 @@ def Lorentzian(f, A, offset, f0, kappa):
     val = offset + A/np.pi * (kappa / ((f-f0)**2 + kappa**2))
     return val
 
-
-def TwinLorentzFunc(f, amplitude_a, amplitude_b, center_a, center_b,
-                    sigma_a, sigma_b, background=0):
+def TwinLorentzFunc(f, A_gf_over_2, A, f0_gf_over_2, f0,
+                    kappa_gf_over_2, kappa, background=0):
     'twin lorentz with background'
-    val = (amplitude_a/np.pi * (sigma_a / ((f-center_a)**2 + sigma_a**2)) +
-           amplitude_b/np.pi * (sigma_b / ((f-center_b)**2 + sigma_b**2)) +
-           background)
+    val = (A_gf_over_2/np.pi * (kappa_gf_over_2 / ((f-f0_gf_over_2)**2 + kappa_gf_over_2**2)) +
+           A/np.pi * (kappa / ((f-f0)**2 + kappa**2)) + background)
     return val
-
 
 def Qubit_dac_to_freq(dac_voltage, f_max, E_c,
                       dac_sweet_spot, V_per_phi0=None, dac_flux_coefficient=None,


### PR DESCRIPTION
Improves inheritance tree, plotting, and some analysis routines in measurement_analysis.py. Improves peak_finder and extends rotate_and_normalize_data based on calibration points in analysis_toolbox.by. Details about the changes made to each module are given below. 
 

Motivation: 
* Several pieces of code, like plotting or call to cal_points calibration method, were duplicated across different analysis routines instead of inheriting from base classes. This produced inconsistent results and plots 
* For the analysis classes listed below, some of the plots were not well-proportioned or would not fit inside the saved PNG figure
* peak_finder would often fail to find good guesses, or analysis routines would fail because peak_finder returned Nones
 
Please let us know if the changes proposed here work for you, and if they can be incorporated into the master. If not, let us know what we can change to make this work for you.

Fixes #327.

Changes proposed in this pull request:

# measurement_analysis.py
Improves
* The following classes
   * MeasurementAnalysis (MA) base
      * Improves main plotting routine _plot_results_vs_sweepparam and includes it in all classes above so that plotting is consistent.
      * Now has attributes for plot line widths and font sizes defined in the _init_, which are used in _plot_results_vs_sweepparam_
      * Adds to default_fig PRL standard figure sizes for 1 or 2 columns, which can be chosen by setting "no_of_columns"
      * Adds method scale_sweep_points that creates "self.scaled_sweep_points", "self.scaled_xlabel", "self.scaled_sweep_unit." These contain correctly scaled values for each experiment (ex: GHz instead of Hz for spectroscopy, us instead of s for Ramsey or T1)
   * Qubit_Spectroscopy_Analysis
      * Adds support for finding the second peak at f_gf/2 from a high power spectroscopy measurement
      * Improves fitting by improving the _analysis_toolbox/peak_finder_ routine to give more accurate parameter guesses 
      * **! Uses the old way of calculating data_dist based on data_amp and data_phase, but the latest version from the origin/master is there and commented out.**
   * Homodyne_Analysis
      * Improves plotting
      * Uses improved  _analysis_toolbox/peak_finder_
   * SSRO_Analysis
      * reorganize functions inside the analysis: make 2D histogram plotting an independent subroutine
      * make plotting optional as it is the slowest part for small datasets
      * improve the look of the 1D histogram plot
      * add support for leaving out part of the data in the final analysis depending on the result of preselection readout (an additional measurement before the state preparation pulse)
 
   * TD_Analysis (TD) base for all time-domain classes
      * New input parameters: 
         * _for_ef_: perform analysis for the EF transition/ on the second excited state
         * _last_ge_pulse_: for experiments on the EF transition, whether or not a GE pi-pulse was applied before each readout, placing qubit in ground state
         * _start_at_zero_: This parameter is used in _TD.normalize_data_to_calibration_points_ to ensure that the data trace after calibration to cal_points starts at (closest to) zero. Currently only used for _Rabi_Analysis_ to force the cosine data trace to have zero phase (allows to set phase to 0 during fit). 
      * Adds support for 0, 2, 4, or 6 cal_points in _TD.normalize_data_to_calibration_points_
         * 6 cal_points are used in EF measurements. Based on the "last_ge_pulse" parameter, normalize_data_to_calibration_points picks the relevant 4 cal_points from those 6 (I and X180_ef calibration points if last_ge_pulse else X180 and X180_ef calibration points) and sends them to analysis_toolbox/rotate_and_normalize_data
         * 0 or 2 (just I pulses) cal points are used for Rabi on GE because the X180 pulse is typically not calibrated before a Rabi measurement
   * Rabi_Analysis
      * Implements complete Rabi analysis: calibration based on cal_points, result is fitted to cosine model, fit results are plotted, pi-pulse and pi/2-pulse amplitudes are extracted
   * Ramsey_Analysis
      * Adds support for two values of the artificial_detuning keyword argument which must be passed in
      * Now calculates the new qubit frequency based on the old value and the fit results
   * Qscale_Analysis
      * Implements analysis for a DRAG pulse calibration measurement as described in Baur, M. PhD Thesis(2012), and extracts optimal qscale value
   * T1_Analysis
      * No major improvements other than plotting and inheritance structure, as described under "Structure of measurement_analysis module" below
 
**! All time-domain routines above return parameters of interest, self.parameter_name, as DICTIONARIES with keys "parameter_name" and "parameter_name_stderr."** Example: self.T1 = {'T1':T1, 'T1_stderr':T1_stderr}. This was done to allow to save them in the HDF file, using the new _MA.save_computed_parameters_.
 
* Structure of measurement_analysis module 
   * Improves inheritance structure for the classes above: both _init_ and _run_default_analysis_ of specific analysis classes follow the trees: (specific time-domain classes -> TD -> MA) or 
(Qubit_Spectroscopy_Analysis/Homodyne_Analysis -> MA). Hence, plot of measured_values vs sweep_points is always done in _MA.run_default_analysis()_, and time-domain classes (except Qscale and Ramsey for 2 artificial detunings) plot fit results on self.fig and self.ax created in TD, which just plots data after calibration based on cal_points.
   * Each of the classes above takes "qb_name" which allows to retrieve previously measured values of the parameters of interest and display them in the text boxes underneath the plots. **Ramsey_Analysis must be given qb_name to retrieve last measured value of qubit frequency in order to correctly calculate new qubit frequency.**
 
# analysis_toolbox.py
Improves
* peak_finder
   * If the parameter optimize==False (default), identical to old peak_finder routine (now renamed to look_for_peaks_dips), which was also improved
   * If optimize==True, reruns look_for_peaks_dips until it finds tallest peak/smallest dip in the data set
   * This does not break usage of peak_finder as the old routine throughout measurement_analysis.py
* rotate_and_normalize_data
   * Adds support for 0 and 2 calibration points

Adds
* look_for_peaks_dips
   * Original peak_finder improved and renamed
* find_second_peak
   * Finds second largest peak/smallest dip in a data set; used for finding f_gf/2 in Qubit_Spectroscopy_Analysis
* rotate_and_normalize_data_no_cal_points
 
# fitting_models.py
Changes
* TwinLorentzFunc input parameter names renamed

@AdriaanRol 



