### PR TITLE
Fix ordering of channels in UHFQC detector function

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -471,7 +471,7 @@ class UHFQC(Instrument):
 
         return data
 
-    def acquisition_initialize(self, channels=set([0, 1]), mode='rl'):
+    def acquisition_initialize(self, channels=(0, 1), mode='rl'):
         # Define the channels to use and subscribe to them
         self.acquisition_paths = []
 

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -1275,7 +1275,7 @@ class UHFQC_input_average_detector(Hard_Detector):
         data_raw = self.UHFQC.acquisition_poll(samples=self.nr_sweep_points,
                                                arm=False, acquisition_time=0.01)
         data = np.array([data_raw[key]
-                         for key in data_raw.keys()])  # *self.scaling_factor
+                         for key in sorted(data_raw.keys())])  # *self.scaling_factor
 
         return data
 
@@ -1426,13 +1426,14 @@ class UHFQC_integrated_average_detector(Hard_Detector):
         self.UHFQC.quex_rl_readout(1)  # resets UHFQC internal readout counters
         self.UHFQC.acquisition_arm()
         # starting AWG
+
         if self.AWG is not None:
             self.AWG.start()
 
         data_raw = self.UHFQC.acquisition_poll(
             samples=self.nr_sweep_points, arm=False, acquisition_time=0.01)
         data = np.array([data_raw[key]
-                         for key in data_raw.keys()])*self.scaling_factor
+                         for key in sorted(data_raw.keys())])*self.scaling_factor
 
         # Corrects offsets after crosstalk suppression matrix in UFHQC
         if self.result_logging_mode == 'lin_trans':
@@ -1653,10 +1654,10 @@ class UHFQC_correlation_detector(UHFQC_integrated_average_detector):
 
         data = []
         if self.thresholding:
-            for key in data_raw.keys():
+            for key in sorted(data_raw.keys()):
                 data.append(np.array(data_raw[key]))
         else:
-            for key in data_raw.keys():
+            for key in sorted(data_raw.keys()):
                 if key in self.correlation_channels:
                     data.append(np.array(data_raw[key]) *
                                 (self.scaling_factor**2 / self.nr_averages))
@@ -1738,7 +1739,7 @@ class UHFQC_integration_logging_det(Hard_Detector):
         data_raw = self.UHFQC.acquisition_poll(
             samples=self.nr_shots, arm=False, acquisition_time=0.01)
         data = np.array([data_raw[key]
-                         for key in data_raw.keys()])*self.scaling_factor
+                         for key in sorted(data_raw.keys())])*self.scaling_factor
 
         # Corrects offsets after crosstalk suppression matrix in UFHQC
         if self.result_logging_mode == 'lin_trans':


### PR DESCRIPTION
The channels where put in an array by looping over dict.keys(), which was not guaranteed to preserve ordering. By sorting the keys we guarantee the ordering is the same as the order in which the acquisition channels were defined.

