### PR TITLE
Changed powerlimits from -2, 2 to -4, 4

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -618,7 +618,7 @@ class MeasurementAnalysis(object):
         # set axes labels format to scientific when outside interval [0.01,99]
         from matplotlib.ticker import ScalarFormatter
         fmt = ScalarFormatter()
-        fmt.set_powerlimits((-2, 2))
+        fmt.set_powerlimits((-4, 4))
         ax.xaxis.set_major_formatter(fmt)
         ax.yaxis.set_major_formatter(fmt)
 


### PR DESCRIPTION
Changed exponent at which scientific notation kicks in. 

See figures below for example of use. 

Here the scientific exponent does not add anything and IMO only makes it less easy to read in one glance. 
![image](https://user-images.githubusercontent.com/6142932/32062126-db46cd30-ba73-11e7-8755-ec7773904fc7.png)

Here it is easily readable. 
![image](https://user-images.githubusercontent.com/6142932/32062131-dcf86a58-ba73-11e7-904b-a9c0bcbdc769.png)

IMO numbers up to thousands are easily readable (e.g., 4096 vs 4e3). Above that scientific notation could be useful. 

@antsr @Vintrix I'm asking you to review as you have introduced the change. I guess I should have paid more attention when reviewing. 
