### PR TITLE
Fixes bug in Qubit_Spectroscopy_Analysis where

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -4924,7 +4924,7 @@ class Qubit_Spectroscopy_Analysis(MeasurementAnalysis):
                                         y=self.data_dist,
                                         fig=fig_dist, ax=ax_dist,
                                         xlabel=self.sweep_name,
-                                        x_unit=self.sweep_unit,
+                                        x_unit=self.sweep_unit[0],
                                         ylabel='S21 distance (arb.units)',
                                         label=False,
                                         save=False)
@@ -4954,7 +4954,7 @@ class Qubit_Spectroscopy_Analysis(MeasurementAnalysis):
                          'k--', linewidth=self.line_width)
 
         scale = SI_prefix_and_scale_factor(val=max(abs(ax_dist.get_xticks())),
-                                           unit=self.sweep_unit)[0]
+                                           unit=self.sweep_unit[0])[0]
 
         instr_set = self.data_file['Instrument settings']
 


### PR DESCRIPTION
Fixes a bug in Qubit_Spectroscopy_Analysis where the units for the xlabel were not extracted
correctly from self.sweep_unit.

Fixes #386.

Changes proposed in this pull request:
In the DCL master version, in measurement_analysis.py:

* line 4927: x_unit=self.sweep_unit ---> x_unit=self.sweep_unit[0]
* line 4957: unit=self.sweep_unit ---> unit=self.sweep_unit[0]

Since this unit was incorrectly retrieved, the set_xlabel function did not receive the correct units, and the x-axis was in Hz instead of GHz.


@AdriaanRol  



