### PR TITLE
Fixed ylabels for 2D plotting in MC

### DIFF
--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -628,7 +628,7 @@ class MeasurementControl(Instrument):
                                           y=self.sweep_pts_y,
                                           z=self.TwoD_array[:, :, j],
                                           xlabel=slabels[0], xunit=sunits[0],
-                                          ylabel=sunits[1], yunit=sunits[1],
+                                          ylabel=slabels[1], yunit=sunits[1],
                                           zlabel=zlabels[j], zunit=zunits[j],
                                           subplot=j+1,
                                           cmap='viridis')


### PR DESCRIPTION
Fixes a bug in the liveplotting where in heatmaps the y-axis was wrongly displaying the unit twice and not displaying the label/parameter name. 