### PR TITLE
Fixes the x-axis for QX simulator in Quantum Infinity

### DIFF
--- a/pycqed/measurement/demonstrator_helper/simulation_helpers.py
+++ b/pycqed/measurement/demonstrator_helper/simulation_helpers.py
@@ -58,6 +58,8 @@ def _simulate_QX(file_path, options):
         qxc.connect()
         qxc.create_qubits(2)
         qx_sweep = swf.QX_Hard_Sweep(qxc, file_path)
+        qx_sweep.parameter_name = 'Circuit number '
+        qx_sweep.unit = '#'
         num_avg = options.get('num_avg', 10000)  # 10000 is the default
 
         qx_detector = QX_Hard_Detector(qxc, [file_path], num_avg=num_avg)


### PR DESCRIPTION
Fixes issue #413 by just adding the parameter_name and unit for the qx simulator in the simulation_helper file.