### PR TITLE
CMA optimization test + small changes to the MC 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,14 @@ install:
     - conda update conda --yes
     - conda create -n test_env python=${PYTHON} --yes
     - source activate test_env
-    - conda install numpy scipy pyopengl pytest flake8 six coverage matplotlib --yes
+    - conda install numpy --yes
+    - conda install scipy --yes
+    - conda install pyopengl --yes
+    - conda install pytest --yes
+    - conda install flake8 --yes
+    - conda install six --yes
+    - conda install coverage --yes
+    - conda install matplotlib --yes
     - conda install -c bioconda pygraphviz --yes
     - conda install cython --yes
     - conda install pyqt --yes;

--- a/pycqed/instrument_drivers/physical_instruments/dummy_instruments.py
+++ b/pycqed/instrument_drivers/physical_instruments/dummy_instruments.py
@@ -20,7 +20,7 @@ class DummyParHolder(Instrument):
         super().__init__(name, **kw)
 
         # Instrument parameters
-        for parname in ['x', 'y', 'z']:
+        for parname in ['x', 'y', 'z', 'x0', 'y0', 'z0']:
             self.add_parameter(parname, unit='m',
                                parameter_class=ManualParameter,
                                vals=vals.Numbers(), initial_value=0)
@@ -55,8 +55,10 @@ class DummyParHolder(Instrument):
 
     def _measure_parabola(self):
         time.sleep(self.delay())
-        return (self.x()**2 + self.y()**2 + self.z()**2 +
-                self.noise()*np.random.rand(1))
+        return ((self.x()-self.x0())**2 +
+                       (self.y()-self.y0())**2 +
+                       (self.z()-self.z0())**2 +
+                        self.noise()*np.random.rand(1))
 
     def _measure_skewed_parabola(self):
         '''

--- a/pycqed/tests/test_MeasurementControl.py
+++ b/pycqed/tests/test_MeasurementControl.py
@@ -329,12 +329,44 @@ class Test_MeasurementControl(unittest.TestCase):
              'x0': [-50, -50], 'initial_step': [2.5, 2.5]})
         self.mock_parabola.noise(.5)
         self.MC.set_detector_function(self.mock_parabola.parabola)
-        dat = self.MC.run('1D test', mode='adaptive')
+        dat = self.MC.run('nelder-mead test', mode='adaptive')
         dset = dat["dset"]
         xf, yf, pf = dset[-1]
         self.assertLess(xf, 0.7)
         self.assertLess(yf, 0.7)
         self.assertLess(pf, 0.7)
+
+    def test_adaptive_measurement_cma(self):
+        """
+        Example on how to use the cma-es evolutionary algorithm.
+        Test contains comments on options that can be used
+        """
+        # import included in the test to avoid whole suite failing if missing
+        import cma
+
+        self.mock_parabola.noise(1)
+        self.MC.set_sweep_functions(
+            [self.mock_parabola.x, self.mock_parabola.y,
+             self.mock_parabola.z])
+        self.MC.set_adaptive_function_parameters(
+            {'adaptive_function': cma.fmin,
+             'x0': [-5, 5, 5], 'sigma0': 1,
+             # options for the CMA algorithm can be found using
+             # "cma.CMAOptions()"
+             'options': {'maxfevals': 5000,    # maximum function cals
+                         # Scaling for individual sigma's
+                         'cma_stds': [5, 6, 3],
+                         'ftarget': 0.005},     # Target function value
+             })
+        self.mock_parabola.noise(.5)
+        self.MC.set_detector_function(self.mock_parabola.parabola)
+        dat = self.MC.run('CMA test', mode='adaptive')
+        x_opt = self.MC.adaptive_result[0]
+        x_mean = self.MC.adaptive_result[5]
+
+        for i in range(3):
+            self.assertLess(x_opt[i], 0.1)
+            self.assertLess(x_mean[i], 0.1)
 
     def test_adaptive_measurement_SPSA(self):
         self.MC.soft_avg(1)
@@ -353,7 +385,7 @@ class Test_MeasurementControl(unittest.TestCase):
              'maxiter': 330})
         self.mock_parabola.noise(.5)
         self.MC.set_detector_function(self.mock_parabola.parabola)
-        dat = self.MC.run('1D test', mode='adaptive')
+        dat = self.MC.run('SPSA test', mode='adaptive')
         dset = dat["dset"]
         xf, yf, pf = dset[-1]
         self.assertLess(xf, 0.7)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 qutip
 pyqtgraph
 pygsti
+cma


### PR DESCRIPTION
Changes proposed in this pull request:
- Example test for how to use CMA-ES optimization algorithm 
- Test that demonstrates how to use it. 

Below a mock example of how to use cma optimization. 
```python 
mock_parabola.noise(10)
MC.set_sweep_functions(
    [mock_parabola.x, mock_parabola.y, mock_parabola.z])
MC.set_adaptive_function_parameters(
    {'adaptive_function': cma.fmin,
     'x0': [-5, 5, 5], 'sigma0': 5,  
     # options for the CMA algorithm can be found using "cma.CMAOptions()"
    'options':{'maxfevals': 5000,      # maximum function cals 
               'cma_stds': [1, 1, 10], # Scaling for individual sigma's 
               'ftarget': 0.05},        # Target function value
            })
mock_parabola.noise(.5)
MC.set_detector_function(mock_parabola.parabola)
dat = MC.run('CMA test', mode='adaptive')
```