### PR TITLE
Openql-0.6 compatibility

### DIFF
--- a/pycqed/measurement/openql_experiments/multi_qubit_oql.py
+++ b/pycqed/measurement/openql_experiments/multi_qubit_oql.py
@@ -1087,7 +1087,12 @@ def conditional_oscillation_seq(q0: int, q1: int, platf_cfg: str,
 
     p.sweep_points = np.concatenate(
         [np.repeat(angles, len(cases)), cal_pts_idx])
-    p.set_sweep_points(p.sweep_points, len(p.sweep_points))
+    # FIXME: remove try-except, when we depend hardly on >=openql-0.6
+    try:
+        p.set_sweep_points(p.sweep_points)
+    except TypeError:
+        # openql-0.5 compatibility
+        p.set_sweep_points(p.sweep_points, len(p.sweep_points))
     return p
 
 
@@ -1615,5 +1620,10 @@ def sliding_flux_pulses_seq(
         cal_pts_idx = []
 
     p.sweep_points = np.concatenate([angles, cal_pts_idx])
-    p.set_sweep_points(p.sweep_points, len(p.sweep_points))
+    # FIXME: remove try-except, when we depend hardly on >=openql-0.6
+    try:
+        p.set_sweep_points(p.sweep_points)
+    except TypeError:
+        # openql-0.5 compatibility
+        p.set_sweep_points(p.sweep_points, len(p.sweep_points))
     return p

--- a/pycqed/measurement/openql_experiments/pygsti_oql.py
+++ b/pycqed/measurement/openql_experiments/pygsti_oql.py
@@ -39,7 +39,12 @@ def openql_program_from_pygsti_expList(expList, program_name: str,
         p = oqh.compile(p)
 
     p.sweep_points = np.arange(len(expList), dtype=float) + start_idx
-    p.set_sweep_points(p.sweep_points, len(p.sweep_points))
+    # FIXME: remove try-except, when we depend hardly on >=openql-0.6
+    try:
+        p.set_sweep_points(p.sweep_points)
+    except TypeError:
+        # openql-0.5 compatibility
+        p.set_sweep_points(p.sweep_points, len(p.sweep_points))
 
     return p
 

--- a/pycqed/measurement/openql_experiments/single_qubit_oql.py
+++ b/pycqed/measurement/openql_experiments/single_qubit_oql.py
@@ -413,7 +413,12 @@ def idle_error_rate_seq(nr_of_idle_gates,
             p.add_kernel(k)
         sweep_points.append(N)
 
-    p.set_sweep_points(sweep_points, num_sweep_points=len(sweep_points))
+    # FIXME: remove try-except, when we depend hardly on >=openql-0.6
+    try:
+        p.set_sweep_points(sweep_points)
+    except TypeError:
+        # openql-0.5 compatibility
+        p.set_sweep_points(sweep_points, num_sweep_points=len(sweep_points))
     p.sweep_points = sweep_points
     p = oqh.compile(p)
     return p
@@ -859,5 +864,10 @@ def ef_rabi_seq(q0: int,
         cal_pts_idx = []
 
     p.sweep_points = np.concatenate([amps, cal_pts_idx])
-    p.set_sweep_points(p.sweep_points, len(p.sweep_points))
+    # FIXME: remove try-except, when we depend hardly on >=openql-0.6
+    try:
+        p.set_sweep_points(p.sweep_points)
+    except TypeError:
+        # openql-0.5 compatibility
+        p.set_sweep_points(p.sweep_points, len(p.sweep_points))
     return p


### PR DESCRIPTION
This time normal MR. Both OpenQL-0.5 and OpenQL-0.6 should work now. Fixes `set_sweep_points` interface change (no, we don't know `DeprecationWarning`)