### PR TITLE
Hotfix/ccl mc/load emptylines

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
+++ b/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
@@ -197,6 +197,7 @@ class CCLightMicrocode():
                                     cs_line, idx))
 
     def load_microcode(self, filename):
+        print("file to load by mc: ", filename)
         try:
             mc_config = open(filename, 'r', encoding='utf-8')
             logging.info("opened file {} successfully.".format(filename))
@@ -208,8 +209,13 @@ class CCLightMicrocode():
         mc_config.readline()
 
         for line in mc_config:
+            # throw away empty lines
+            if not line.rstrip():
+                continue
+
             # remove the ':' character
             line = line.translate({ord(":"): None})
+            print("line to split: ", line)
             # get each number in the line
             line_number, condition, op_type_left, cw_left,\
                 op_type_right, cw_right = line.split()

--- a/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
+++ b/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
@@ -197,7 +197,6 @@ class CCLightMicrocode():
                                     cs_line, idx))
 
     def load_microcode(self, filename):
-        print("file to load by mc: ", filename)
         try:
             mc_config = open(filename, 'r', encoding='utf-8')
             logging.info("opened file {} successfully.".format(filename))
@@ -215,30 +214,24 @@ class CCLightMicrocode():
 
             # remove the ':' character
             line = line.translate({ord(":"): None})
-            print("line to split: ", line)
+
             # get each number in the line
             line_number, condition, op_type_left, cw_left,\
                 op_type_right, cw_right = line.split()
 
             line_number = int(line_number)
-            # print("line_number: ", line_number, " ", end= "")
             condition = int(condition)
-            # print("condition: ", condition, " ", end= "")
             op_type_left = int(op_type_left)
-            # print("op_type_left: ", op_type_left, " ", end= "")
             cw_left = int(cw_left)
-            # print("cw_left: ", cw_left, " ", end= "")
             op_type_right = int(op_type_right)
-            # print("op_type_right: ", op_type_right, " ", end= "")
             cw_right = int(cw_right)
-            # print("cw_right: ", cw_right, " ", end= "")
+
             if line_number > 256:
                 raise ValueError("line number ({}) in the file "
                                  "exceeds the maximum value (256).")
 
             self.microcode[line_number] = self.gen_control_store_line(
                 condition, op_type_left, cw_left, op_type_right, cw_right)
-            # print(self.microcode[line_number])
 
     def write_to_bin(self, filename=None):
         bin_data = bytearray()


### PR DESCRIPTION
Please use the following template for a pull request. 

When the readable control store file (see following for an example) has an empty line, the function `load_microcode` of CCL_Microcode would crash. 

```
        Condition  OpTypeLeft  CW_Left  OpTypeRight  CW_Right
    0:      0          0         0           0            0
    1:      0          1         1           0            0
...
```

Changes proposed in this pull request:
- Throw away empty lines when reading the readable control store configuration file.

@AdriaanRol 
