### PR TITLE
pin plotly version in Dockerfile

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -23,7 +23,7 @@ RUN pip install --upgrade --no-cache-dir pip && \
         "matplotlib<2.3" \
         # required by qcodes-0.1.11
         "numpy<1.14" \
-        plotly \
+        "plotly<3.8" \
         PyQt5 \
         scipy \
         pandas && \


### PR DESCRIPTION
This fixes a problem of dependency resolution with pip: despite the fact that pyGSTi requires `plotly<=3.7.1`, the image appears to have later plotly. We pin the plotly version in Dockerfile explisitly. May be we will need to revert this, when pyGSTi guys will manage to update for later plotly.