### PR TITLE
Enh/535/enable real time kernels

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/lfilt_kernel_object.py
+++ b/pycqed/instrument_drivers/meta_instrument/lfilt_kernel_object.py
@@ -1,6 +1,7 @@
 """
 This file contains an instrument for correcting distortions
-using linear filtering (scipy.signal.lfilter).
+using linear filtering (scipy.signal.lfilter) and/or setting
+the real-time distortion corrections in the HDAWG instrument.
 
 It is based on the kernel_object.DistortionsKernel
 """

--- a/pycqed/instrument_drivers/meta_instrument/lfilt_kernel_object.py
+++ b/pycqed/instrument_drivers/meta_instrument/lfilt_kernel_object.py
@@ -54,8 +54,6 @@ class LinDistortionKernel(Instrument):
         for filt_id in range(self._num_models):
             self.set('filter_model_{:02}'.format(filt_id), {})
 
-
-
     def get_first_empty_filter(self):
         """
         Resets all kernels to an empty dict so no distortion is applied.
@@ -76,7 +74,8 @@ class LinDistortionKernel(Instrument):
             AWG = self.instr_AWG.get_instr()
         except Exception as e:
             logging.warning(e)
-            logging.warning('Could not set realtime distortions to 0, AWG not found')
+            logging.warning(
+                'Could not set realtime distortions to 0, AWG not found')
             return
 
         # set exp_filters to 0
@@ -102,16 +101,22 @@ class LinDistortionKernel(Instrument):
                          inverse: bool=False):
         """
         Distorts a waveform using the models specified in the Kernel Object.
+
         Args:
             waveform (array)    : waveform to be distorted
             lenght_samples (int): number of samples after which to cut of wf
             inverse (bool)      : if True apply the inverse of the waveform.
 
-        Returns:
+        Return:
             y_sig (array)       : waveform with distortion filters applied
 
-        N.B. the bounce correction does not have an inverse implemented
+        N.B. The bounce correction does not have an inverse implemented
             (June 2018) MAR
+        N.B.2 The real-time FIR also does not have an inverse implemented.
+            (May 2019) MAR
+        N.B.3 the real-time distortions are reset and set on the HDAWG every
+            time a waveform is distorted. This is a suboptimal workflow.
+
         """
         if length_samples is not None:
             extra_samples = length_samples - len(waveform)
@@ -211,7 +216,8 @@ class LinDistortionKernel(Instrument):
                         if not inverse:
                             y_sig = signal.lfilter(fir_filter_coeffs, 1, y_sig)
                         elif inverse:
-                            y_sig = signal.lfilter(np.ones(1), fir_filter_coeffs, y_sig)
+                            y_sig = signal.lfilter(
+                                np.ones(1), fir_filter_coeffs, y_sig)
 
                 else:
                     raise KeyError('Model {} not recognized'.format(model))

--- a/pycqed/instrument_drivers/virtual_instruments/virtual_AWG8.py
+++ b/pycqed/instrument_drivers/virtual_instruments/virtual_AWG8.py
@@ -48,9 +48,18 @@ class VirtualAWG8(Instrument):
                                initial_value=0.8,
                                parameter_class=ManualParameter)
             # Adding precompensation pars
+            self.add_parameter('sigouts_{}_precompensation_enable'.format(i),
+                               parameter_class=ManualParameter)
+            self.add_parameter(
+                'sigouts_{}_precompensation_fir_enable'.format(i),
+                parameter_class=ManualParameter)
+            self.add_parameter(
+                'sigouts_{}_precompensation_fir_coefficients'.format(i),
+                parameter_class=ManualParameter)
+
             for j in range(8):
                 self.add_parameter('sigouts_{}_precompensation_exponentials'
-                                   '_{}_timecofnstant'.format(i, j),
+                                   '_{}_timeconstant'.format(i, j),
                                    parameter_class=ManualParameter)
                 self.add_parameter('sigouts_{}_precompensation_exponentials'
                                    '_{}_amplitude'.format(i, j),

--- a/pycqed/tests/test_lfilt_kernel_object.py
+++ b/pycqed/tests/test_lfilt_kernel_object.py
@@ -19,16 +19,15 @@ class Test_LinDistortionKernelObject(unittest.TestCase):
         self.k0.filter_model_01({'model': 'exponential',
                                  'params': {'amp': 4.2035373039155806, 'tau': 5.9134605614601521e-06}})
 
-
     def test_print_overview(self):
         # only test that it doesn't raise errors
         self.k0.print_overview()
 
     def test_distort_waveform(self):
-        my_sqaure = np.ones(20)
-        self.k0.distort_waveform(my_sqaure)
+        my_square = np.ones(20)
+        self.k0.distort_waveform(my_square)
 
-        self.k0.distort_waveform(my_sqaure, length_samples=1000)
+        self.k0.distort_waveform(my_square, length_samples=1000)
 
     def test_get_first_empty_kernel(self):
         first_empty = self.k0.get_first_empty_filter()
@@ -46,6 +45,33 @@ class Test_LinDistortionKernelObject(unittest.TestCase):
         self.k0.reset_kernels()
         read_back = self.k0.filter_model_00()
         self.assertEqual({}, read_back)
+
+
+    def test_setting_realtime_filter(self):
+        self.k0.reset_kernels()
+        self.k0.cfg_gain_correction(1)
+
+        tau = 4.071755778296734e-05
+        self.k0.filter_model_00(
+            {'model': 'exponential',
+             'real-time': True,
+             'params': {'tau': tau, 'amp': 0.1}})
+        my_square = np.ones(20)
+        distorted_square = self.k0.distort_waveform(my_square)
+        assert (my_square == distorted_square[:20]).all()
+
+        self.k0.cfg_awg_channel(1)
+        amp = self.AWG.sigouts_0_precompensation_exponentials_0_amplitude()
+        assert amp == 0.1
+        set_tau = self.AWG.sigouts_0_precompensation_exponentials_0_timeconstant()
+        assert set_tau == tau
+
+        # Add tests for enabling realtime fiters
+
+
+
+
+
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
Fixes #535 .

Changes proposed in this pull request:
- `lfilt_kernel_object` now enables distortions when used
- `lfilt_kernel_object` now supports realtime FIR correction
- Tests added for `lfilt_kernel_object` 

Ready for testing. 

@lmjanssen , I've flagged you for review as you are currently using the realtime distortions. Let's take a look at this together on Monday. 

