### PR TITLE
QWG: add wlist and wlistSize to the snapshot exclude

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
@@ -423,19 +423,21 @@ class QuTech_AWG_Module(SCPI):
                 self._params_exclude_snapshot.append(cw_param)
 
         # Waveform parameters
-        wlist_size = self.add_parameter('WlistSize',
-                                        label='Waveform list size',
-                                        unit='#',
-                                        get_cmd='wlist:size?',
-                                        get_parser=int,
-                                        snapshot_exclude=True)
-        self._params_exclude_snapshot.append(wlist_size)
+        self.add_parameter('WlistSize',
+                           label='Waveform list size',
+                           unit='#',
+                           get_cmd='wlist:size?',
+                           get_parser=int,
+                           snapshot_exclude=True)
+        # TODO: Remove when QCodes PR #1653 is merged, see PycQED_py3 issue #566
+        self._params_exclude_snapshot.append('WlistSize')
 
-        wlist = self.add_parameter('Wlist',
-                                   label='Waveform list',
-                                   get_cmd=self._getWlist,
-                                   snapshot_exclude=True)
-        self._params_exclude_snapshot.append(wlist)
+        self.add_parameter('Wlist',
+                           label='Waveform list',
+                           get_cmd=self._getWlist,
+                           snapshot_exclude=True)
+        # TODO: Remove when QCodes PR #1653 is merged, see PycQED_py3 issue #566
+        self._params_exclude_snapshot.append('Wlist')
 
         self.add_parameter('get_system_status',
                            unit='JSON',

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
@@ -423,14 +423,19 @@ class QuTech_AWG_Module(SCPI):
                 self._params_exclude_snapshot.append(cw_param)
 
         # Waveform parameters
-        self.add_parameter('WlistSize',
-                           label='Waveform list size',
-                           unit='#',
-                           get_cmd='wlist:size?',
-                           get_parser=int)
-        self.add_parameter('Wlist',
-                           label='Waveform list',
-                           get_cmd=self._getWlist)
+        wlist_size = self.add_parameter('WlistSize',
+                                        label='Waveform list size',
+                                        unit='#',
+                                        get_cmd='wlist:size?',
+                                        get_parser=int,
+                                        snapshot_exclude=True)
+        self._params_exclude_snapshot.append(wlist_size)
+
+        wlist = self.add_parameter('Wlist',
+                                   label='Waveform list',
+                                   get_cmd=self._getWlist,
+                                   snapshot_exclude=True)
+        self._params_exclude_snapshot.append(wlist)
 
         self.add_parameter('get_system_status',
                            unit='JSON',


### PR DESCRIPTION
Added to workaround: #566 

Added;
* QWG: add wlist and wlistSize to the snapshot exclude

@AdriaanRol 