### PR TITLE
Updated to not disconnect the instruments when 'close' is called. Now…

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -214,6 +214,9 @@ class UHFQC(zibase.ZI_base_instrument):
         # Used for extra DIO output to CC for debugging
         self._diocws = None
         
+        # Holds the DIO calibration delay
+        self._dio_calibration_delay = 0
+
         # Define parameters that should not be part of the snapshot
         self._params_to_exclude = set(['features_code', 'system_fwlog', 'system_fwlogenable'])
 
@@ -417,6 +420,10 @@ class UHFQC(zibase.ZI_base_instrument):
             be required to address the maximum number of qubits supported by the instrument (10). Therefore,
             the 'cases' mechanism is used to reduce that number to the combinations actually needed by
             an experiment.
+          dio_calibration_delay - the delay that is programmed on the DIO lines as part of the DIO calibration
+            process in order for the instrument to reliably sample data from the CC. Can be used to detect
+            unexpected changes in timing of the entire system. The parameter can also be used to force a specific
+            delay to be used on the DIO although that is not generally recommended.
         """
         super()._add_extra_parameters()
 
@@ -464,6 +471,31 @@ class UHFQC(zibase.ZI_base_instrument):
             'an AWG program that handles only codewords 1, 5 and 7. When running, if the AWG receives a codeword '
             'that is not part of this list, an error will be triggered.',
             vals=validators.Lists())
+
+        self.add_parameter('dio_calibration_delay',
+                           set_cmd=self._set_dio_calibration_delay,
+                           get_cmd=self._get_dio_calibration_delay,
+                           unit='',
+                           label='DIO Calibration delay',
+                           docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
+                           'to be applied on the DIO interface in order to achieve reliable sampling'
+                           ' of the codewords. The valid range is 0 to 15.',
+                           vals=validators.Ints())
+
+    def _set_dio_calibration_delay(self, value):
+        # Sanity check the value
+        if value < 0 or value > 15:
+            raise zibase.ziValueError('Trying to set DIO calibration delay to invalid value! Expected value in range 0 to 15. Got {}.'.format(value))
+
+        log.info('Setting DIO calibration delay to {}'.format(value))
+        # Store the value
+        self._dio_calibration_delay = value
+        
+        # And configure the delays
+        self.setd('raw/dios/0/delay', self._dio_calibration_delay)
+
+    def _get_dio_calibration_delay(self):
+        return self._dio_calibration_delay
 
     def _set_wait_dly(self, value):
         self.set('awgs_0_userregs_{}'.format(UHFQC.USER_REG_WAIT_DLY), value)
@@ -1613,7 +1645,8 @@ setTrigger(0);
             time.sleep(1)
             valid_sequence = True
             for awg in [0]:
-                if self.geti('raw/dios/0/error/timing') & combined_mask != 0:
+                error_timing = self.geti('raw/dios/0/error/timing')
+                if error_timing & combined_mask != 0:
                     valid_sequence = False
 
             if valid_sequence:
@@ -1622,7 +1655,8 @@ setTrigger(0);
         return set(valid_delays)
 
     def _prepare_CCL_dio_calibration(self, CCL, feedline=1, verbose=False):
-
+        """Configures a CCL with a default program that generates data suitable for DIO calibration.
+        Also starts the program."""
         cs_filepath = os.path.join(pycqed.__path__[0],
                 'measurement',
                 'openql_experiments',
@@ -1654,6 +1688,7 @@ setTrigger(0);
             raise ziValueError('Invalid feedline {} selected for calibration.'.format(feedline))
             
     def _prepare_QCC_dio_calibration(self, QCC, verbose=False):
+        """Configures a QCC with a default program that generates data suitable for DIO calibration. Also starts the QCC."""
 
         cs_filepath = os.path.join(pycqed.__path__[0],
                 'measurement',
@@ -1681,6 +1716,24 @@ setTrigger(0);
         # Set the DIO calibration mask to enable 9 bit measurement
         self._dio_calibration_mask = 0x1ff
 
+    def _prepare_HDAWG8_dio_calibration(self, HDAWG, verbose=False):
+        """Configures an HDAWG with a default program that generates data suitable for DIO calibration. Also starts the HDAWG."""
+        program = '''
+var A = 0xffff0000;
+var B = 0x00000000;
+
+while (1) {
+  setDIO(A);
+  wait(2);
+  setDIO(B);
+  wait(2);
+}
+'''
+        HDAWG.configure_awg_from_string(0, program)
+        HDAWG.seti('awgs/0/enable', 1)
+
+        self._dio_calibration_mask = 0x7fff
+
     def calibrate_CC_dio_protocol(self, CC, feedline=None, verbose=False, repetitions=1):
         log.info('Calibrating DIO delays')
         if verbose: print("Calibrating DIO delays")
@@ -1689,11 +1742,13 @@ setTrigger(0);
 
         CC_model = CC.IDN()['model']
         if 'QCC' in CC_model:
-            expected_sequence = self._prepare_QCC_dio_calibration(
+            self._prepare_QCC_dio_calibration(
                 QCC=CC, verbose=verbose)
         elif 'CCL' in CC_model:
-            expected_sequence = self._prepare_CCL_dio_calibration(
+            self._prepare_CCL_dio_calibration(
                 CCL=CC, feedline=feedline, verbose=verbose)
+        elif 'HDAWG8' in CC_model:
+            self._prepare_HDAWG8_dio_calibration(HDAWG=CC, verbose=verbose)
         else:
             raise ValueError('CC model ({}) not recognized.'.format(CC_model))
 
@@ -1718,7 +1773,7 @@ setTrigger(0);
         if verbose: print("  Setting delay to {}".format(min_valid_delay))
 
         # And configure the delays
-        self.setd('raw/dios/0/delay', min_valid_delay)
+        self._set_dio_calibration_delay(min_valid_delay)
 
         # Clear all detected errors (caused by DIO timing calibration)
         self.clear_errors()

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -350,9 +350,9 @@ class UHFQC(zibase.ZI_base_instrument):
         Checks that the correct options are installed on the instrument.
         """
         options = self.gets('features/options').split('\n')
-        if 'QA' not in options:
+        if 'QA' not in options and 'QC' not in options:
             raise zibase.ziOptionsError(
-                'Device {} is missing the QA option!'.format(self.devname))
+                'Device {} is missing the QA or QC option!'.format(self.devname))
         if 'AWG' not in options:
             raise zibase.ziOptionsError(
                 'Device {} is missing the AWG option!'.format(self.devname))
@@ -1719,4 +1719,7 @@ setTrigger(0);
 
         # And configure the delays
         self.setd('raw/dios/0/delay', min_valid_delay)
+
+        # Clear all detected errors (caused by DIO timing calibration)
+        self.clear_errors()
 

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
@@ -115,6 +115,9 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core):
         super().__init__(name=name, device=device, interface=interface, server=server, port=port, num_codewords=num_codewords, **kw)
         # Set default waveform length to 20 ns at 2.4 GSa/s
         self._default_waveform_length = 48
+        
+        # Holds the DIO calibration delay
+        self._dio_calibration_delay = 0
 
          # show some info
         log.info('{}: DIO interface found in mode {}'
@@ -146,34 +149,42 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core):
         self.seti('raw/error/blinkforever', 1)
 
         t1 = time.time()
-        print('Initialized ZI_HDAWG_core', self.devname, 'in %.2fs' % (t1-t0))
+        print('Initialized ZI_HDAWG8', self.devname, 'in %.2fs' % (t1-t0))
 
     def _add_extra_parameters(self):
-        self.add_parameter('timeout', unit='s',
-                           initial_value=10,
-                           parameter_class=ManualParameter)
-        self.add_parameter(
-            'cfg_num_codewords', label='Number of used codewords', docstring=(
-                'This parameter is used to determine how many codewords to '
-                'upload in "self.upload_codeword_program".'),
-            initial_value=self._num_codewords,
-            # N.B. I have commentd out numbers larger than self._num_codewords
-            # see also issue #358
-            vals=vals.Enum(2, 4, 8, 16, 32),  # , 64, 128, 256, 1024),
-            parameter_class=ManualParameter)
+        """
+        We add a few additional custom parameters on top of the ones defined in the device files. These are:
+        timeout - A specific timeout value in seconds used for the various timeconsuming operations on the device
+          such as waiting for an upload to complete.
+        cfg_num_codewords - determines the maximum number of codewords to be supported by the program that will
+          be uploaded using the "upload_codeword_program" method.
+        cfg_codeword_protocol - determines the specific codeword protocol to use, for example 'microwave' or 'flux'.
+          It determines which bits transmitted over the 32-bit DIO interface are used as actual codeword bits.
+        awgs_[0-3]_sequencer_program_crc32_hash - CRC-32 hash of the currently uploaded sequencer program to enable
+          changes in program to be detected.
+        dio_calibration_delay - the delay that is programmed on the DIO lines as part of the DIO calibration
+            process in order for the instrument to reliably sample data from the CC. Can be used to detect
+            unexpected changes in timing of the entire system. The parameter can also be used to force a specific
+            delay to be used on the DIO although that is not generally recommended.
+        """
+        super()._add_extra_parameters()
 
         self.add_parameter(
             'cfg_codeword_protocol', initial_value='identical',
-            vals=vals.Enum('identical', 'microwave', 'new_microwave', 'new_novsm_microwave', 'flux'), docstring=(
+            vals=validators.Enum('identical', 'microwave', 'new_microwave', 'new_novsm_microwave', 'flux'), docstring=(
                 'Used in the configure codeword method to determine what DIO'
                 ' pins are used in for which AWG numbers.'),
             parameter_class=ManualParameter)
 
-        for i in range(4):
-            self.add_parameter(
-                'awgs_{}_sequencer_program_crc32_hash'.format(i),
-                parameter_class=ManualParameter,
-                initial_value=0, vals=vals.Ints())
+        self.add_parameter('dio_calibration_delay',
+                    set_cmd=self._set_dio_calibration_delay,
+                    get_cmd=self._get_dio_calibration_delay,
+                    unit='',
+                    label='DIO Calibration delay',
+                    docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
+                    'to be applied on the DIO interface in order to achieve reliable sampling'
+                    ' of the codewords. The valid range is 0 to 15.',
+                    vals=validators.Ints())
 
     def snapshot_base(self, update: bool=False,
                       params_to_skip_update =None,
@@ -419,11 +430,13 @@ while (1) {
 
                 # self.set('awgs_{}_dio_mask_value'.format(awg_nr), 2**3-1)
                 # self.set('awgs_{}_dio_mask_shift'.format(awg_nr), 0)
+
         ####################################################
         # Turn on device
         ####################################################
         time.sleep(.05)
-        self.daq.setInt('/' + self.devname + '/awgs/*/enable', 1)
+        for awg_nr in range(int(self._num_channels()//2)):
+            self.set('awgs_{}_enable'.format(awg_nr), 1)
 
         # Disable all function generators
         for param in [key for key in self.parameters.keys() if
@@ -455,21 +468,26 @@ while (1) {
         # AWGS/0/DIO/DATA
 
     ##########################################################################
-    # 'private' functions: parameter support for codewords
+    # 'private' functions: parameter support for DIO calibration delay
     ##########################################################################
 
-    def _add_extra_parameters(self) -> None:
-        super()._add_extra_parameters()
+    def _set_dio_calibration_delay(self, value):
+        # Sanity check the value
+        if value < 0 or value > 15:
+            raise zibase.ziValueError('Trying to set DIO calibration delay to invalid value! Expected value in range 0 to 15. Got {}.'.format(value))
 
-        self.add_parameter(
-            'cfg_codeword_protocol', initial_value='identical',
-            vals=validators.Enum('identical', 'microwave', 'flux', 'new_microwave', 'new_novsm_microwave'), docstring=(
-                'Used in the configure codeword method to determine what DIO'
-                ' pins are used in for which AWG numbers.'),
-            parameter_class=ManualParameter)
+        log.info('Setting DIO calibration delay to {}'.format(value))
+        # Store the value
+        self._dio_calibration_delay = value
+        
+        # And configure the delays
+        self.setd('raw/dios/0/delays/*', self._dio_calibration_delay)
+
+    def _get_dio_calibration_delay(self):
+        return self._dio_calibration_delay
 
     ##########################################################################
-    # 'private' functions: DIO calibrration
+    # 'private' functions: DIO calibration
     ##########################################################################
 
     def _get_awg_dio_data(self, awg):
@@ -708,7 +726,6 @@ while (1) {
         CCL.start()
         return expected_sequence
 
-
     def calibrate_CC_dio_protocol(self, CC, verbose=False, repetitions=1):
         """
         Calibrates the DIO communication between CC and HDAWG.
@@ -739,7 +756,6 @@ while (1) {
         valid_delays = self._find_valid_delays(expected_sequence, repetitions, verbose=verbose)
         if len(valid_delays) == 0:
             raise ziDIOCalibrationError('DIO calibration failed! No valid delays found')
-            return
 
         min_valid_delay = min(valid_delays)
 
@@ -748,9 +764,9 @@ while (1) {
         if verbose: print("  Setting delay to {}".format(min_valid_delay))
 
         # And configure the delays
-        self.setd('raw/dios/0/delays/*', min_valid_delay)
+        self._set_dio_calibration_delay(min_valid_delay)
 
         # If succesful clear all errors and return True
         self.clear_errors()
-        
+
         return True

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
@@ -749,5 +749,8 @@ while (1) {
 
         # And configure the delays
         self.setd('raw/dios/0/delays/*', min_valid_delay)
-        # If succesful return True
+
+        # If succesful clear all errors and return True
+        self.clear_errors()
+        
         return True

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -1331,15 +1331,6 @@ class ZI_base_instrument(Instrument):
 
     def close(self) -> None:
         try:
-            if self._is_device_connected(self.devname):
-                # Stop all AWG's. In case errors are flagged we demote them
-                # to warnings.
-                try:
-                    self.stop()
-                except ziRuntimeError as err:
-                    log.error(str(err))
-                # Disconnect device from server
-                self.daq.disconnectDevice(self.devname)
             # Disconnect application server
             self.daq.disconnect()
         except AttributeError:

--- a/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
+++ b/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
@@ -160,3 +160,9 @@ class Test_UHFQC(unittest.TestCase):
         self.uhf.qas_0_rotations_3(1-1j)
         assert self.uhf.qas_0_rotations_3() == (1-1j)
         self.uhf.reset_rotation_params
+
+    def test_close_open(self):
+        # Close the instrument, then reopen to make sure that we can reconnect
+        Test_UHFQC.uhf.close()
+        self.setup_class()
+        self.assertEqual(Test_UHFQC.uhf.devname, 'dev2109')


### PR DESCRIPTION
… the 'close' method will still work even if the server loses connection to the instrument. Also updated to not stop the running AWGs when 'close' is called (issue 155). Finally, a test was added for the new close behavior. The error stack is now cleared after the DIO calibration completes (in case it completes successfully).

Please use the following template for a pull request. 

Fixes QuSurf issue #155, #163 and #152.


Changes proposed in this pull request:
Updated the 'close' method to not disconnect the instrument from the server. This has the added benefit of solving the problem with the 'close' method not working if the server loses connection to the instrument. Also updated the DIO calibration procedures to clear the error stack after calibration completes successfully so that the user is not swamped by the DIO timing errors detected during calibration. Added a small test of the new close behavior.

@AdriaanRol, @MiguelSMoreira  