### PR TITLE
Feature/zi issue 152

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -885,7 +885,7 @@ setUserReg(4, err_cnt);"""
             self.unsubs(p)
         self.unsubs(self._get_full_path('auxins/0/sample'))
 
-    def check_errors(self) -> None:
+    def check_errors(self, errors_to_ignore=None) -> None:
         """
         Checks the instrument for errors. As the UHFQA does not yet support the same error
         stack as the HDAWG instruments we do the checks by reading specific nodes
@@ -1761,5 +1761,5 @@ while (1) {
         self._set_dio_calibration_delay(delay)
 
         # Clear all detected errors (caused by DIO timing calibration)
-        self.clear_errors()
+        self.check_errors(errors_to_ignore=['AWGDIOTIMING'])
 

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
@@ -479,7 +479,8 @@ while (1) {
         self._dio_calibration_delay = value
 
         # And configure the delays
-        self.setd('raw/dios/0/delays/*', self._dio_calibration_delay)
+        for i in range(32):
+            self.setd('raw/dios/0/delays/' + str(i) + '/value', self._dio_calibration_delay)
 
     def _get_dio_calibration_delay(self):
         return self._dio_calibration_delay

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -312,6 +312,7 @@ class MockDAQServer():
                            str(i) + '/imag'] = {'type': 'ZIVectorData', 'value': np.array([])}
                 self.nodes['/' + self.device + '/qas/0/result/data/' +
                            str(i) + '/wave'] = {'type': 'ZIVectorData', 'value': np.array([])}
+            self.nodes['/' + self.device + '/raw/dios/0/delay'] = {'type': 'Integer', 'value': 0}
         elif self.devtype == 'HDAWG8':
             self.nodes['/' + self.device +
                        '/features/options'] = {'type': 'String', 'value': 'PC\nME'}
@@ -323,6 +324,9 @@ class MockDAQServer():
                        '/raw/error/blinkforever'] = {'type': 'Integer', 'value': 0}
             self.nodes['/' + self.device +
                        '/raw/dios/0/extclk'] = {'type': 'Integer', 'value': 0}
+            for i in range(32):
+                self.nodes['/' + self.device +
+                        '/raw/dios/0/delays/' + str(i) + '/value'] = {'type': 'Integer', 'value': 0}
             for awg_nr in range(4):
                 for i in range(32):
                     self.nodes['/' + self.device + '/awgs/' + str(awg_nr) + '/waveform/waves/' + str(i)] = {

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -1338,7 +1338,7 @@ class ZI_base_instrument(Instrument):
             pass
         super().close()
 
-    def check_errors(self) -> None:
+    def check_errors(self, errors_to_ignore=None) -> None:
         raise NotImplementedError('Virtual method with no implementation!')
 
     def clear_errors(self) -> None:


### PR DESCRIPTION
Fixes #152.

The logic associated with error handling has been changed slightly. First, the general error checking routine no longer reports the number of new errors, as this information is implicitly delivered when the actual errors are reported. In addition, the functionality also interfered with the functionality to ignore errors, i.e. new errors would be reported even if they were on the ignore list.

Second, the `check_errors` method now supports an optional argument that enables a temporary extra list of errors to be ignored. The functionality is used in the DIO calibration routine to now check for errors at the end, but to ignore DIO timing violations. In this way, we no longer clear the list of errors and it should not be possible to lose errors anymore.

@MiguelSMoreira could you have a look if this satisfies your requirements to fix #152?

In order for the pull request to be merged, the following conditions must be met:
- travis test suite passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


