### PR TITLE
Adding a 'sync' method to the MockServer class to support new tests.

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -476,6 +476,12 @@ class MockDAQServer():
         if path in self.poll_nodes:
             self.poll_nodes.remove(path)
 
+    def sync(self):
+        """The sync method does not need to do anything as there are no
+        device delays to deal with when using the mock server.
+        """
+        pass
+
     def _load_parameter_file(self, filename: str):
         """
         Takes in a node_doc JSON file auto generates paths based on


### PR DESCRIPTION
Please use the following template for a pull request. 

Partially fixes #629

Changes proposed in this pull request:
- Added 'sync' method to MockServer class to enable new tests to pass that include <object>.sync() commands.

@MiguelSMoreira, @caenrigen 