### PR TITLE
Added try/except to UHFQC DIO calibration.

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -543,7 +543,7 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
         self.auxins_0_averaging(8)
 
     def acquisition_arm(self, single=True) -> None:
-        time.sleep(0.01)
+        # time.sleep(0.01)
         self.awgs_0_single(single)
         self.start()
 
@@ -1717,33 +1717,54 @@ setTrigger(0);
         log.info(f"{self.devname}: Calibrating DIO protocol")
         self.assure_ext_clock()
 
-        for awg in [0]:
-            if not self._ensure_activity(awg, mask_value=dio_mask):
-                raise ziUHFQCDIOActivityError('No or insufficient activity found on the DIO bits associated with AWG {}'.format(awg))
+        # Get the integration length and result enable settings to be able to
+        # restore them later
+        integration_length = self.get('qas_0_integration_length')
+        result_enable = self.get('qas_0_result_enable')
+        monitor_enable = self.get('qas_0_monitor_enable')
+        awg_enable = self.get('awgs_0_enable')
 
-        valid_delays = self._find_valid_delays(awg, mask_value=dio_mask)
-        if len(valid_delays) == 0:
-            raise ziUHFQCDIOCalibrationError('DIO calibration failed! No valid delays found')
+        try:
+          self.set('qas_0_integration_length', 4)
+          self.set('qas_0_result_enable', 0)
+          self.set('qas_0_monitor_enable', 0)
+          self.set('awgs_0_enable', 0)
+          
+          for awg in [0]:
+              if not self._ensure_activity(awg, mask_value=dio_mask):
+                  raise ziUHFQCDIOActivityError('No or insufficient activity found on the DIO bits associated with AWG {}'.format(awg))
 
-        # Find center of first valid region
-        subseq = [[]]
-        for e in valid_delays:
-            if not subseq[-1] or subseq[-1][-1] == e - 1:
-                subseq[-1].append(e)
-            else:
-                subseq.append([e])
+          valid_delays = self._find_valid_delays(awg, mask_value=dio_mask)
+          if len(valid_delays) == 0:
+              raise ziUHFQCDIOCalibrationError('DIO calibration failed! No valid delays found')
 
-        subseq = max(subseq, key=len)
-        delay = len(subseq)//2 + subseq[0]
+          # Find center of first valid region
+          subseq = [[]]
+          for e in valid_delays:
+              if not subseq[-1] or subseq[-1][-1] == e - 1:
+                  subseq[-1].append(e)
+              else:
+                  subseq.append([e])
 
-        # Print information
-        log.info(f"{self.devname}: Valid delays are {valid_delays}")
+          subseq = max(subseq, key=len)
+          delay = len(subseq)//2 + subseq[0]
 
-        # And configure the delays
-        self._set_dio_calibration_delay(delay)
+          # Print information
+          log.info(f"{self.devname}: Valid delays are {valid_delays}")
 
-        # Clear all detected errors (caused by DIO timing calibration)
-        self.check_errors(errors_to_ignore=['AWGDIOTIMING'])
+          # And configure the delays
+          self._set_dio_calibration_delay(delay)
+
+          # Clear all detected errors (caused by DIO timing calibration)
+          self.check_errors(errors_to_ignore=['AWGDIOTIMING'])
+        
+        finally:
+          # Restore settings either in case of an exception or if the DIO
+          # routine finishes correctly
+          self.set('qas_0_integration_length', integration_length)
+          self.set('qas_0_result_enable', result_enable)
+          self.set('qas_0_monitor_enable', monitor_enable)
+          self.set('awgs_0_enable', awg_enable)
 
     ##########################################################################
     # DIO calibration functions for *CC*


### PR DESCRIPTION
Fixes #188.

Changes proposed in this pull request:
- Updates UHFQA driver with a try/finally statement in the DIO calibration method to change/restore settings before/after DIO calibration to avoid triggering holdoff errors.

@MiguelSMoreira

In order for the pull request to be merged, the following conditions must be met:
- travis test suite passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


