### PR TITLE
[WIP] remove old fix on plotly version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ matplotlib
 pandas
 PyQt5
 pyqtgraph
-pygsti
+pygsti==0.9.7.5
 pyvisa>=1.8
 numpy
 Cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ matplotlib
 pandas
 PyQt5
 pyqtgraph
-pygsti==0.9.6
+pygsti
 pyvisa>=1.8
 numpy
 Cython
@@ -30,5 +30,5 @@ networkx
 scikit-learn==0.23.1  # Tests started to fail on 2020-08-05 due to 0.23.2
 qutechopenql
 zhinst
-plotly<3.8
+plotly
 packaging

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(name='PycQED',
           'Programming Language :: Python :: 3 :: Only',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
           'Topic :: Scientific/Engineering'
       ],
       license=license(),


### PR DESCRIPTION
Changes proposed in this pull request:
- Unpin the `plotly` and `pyGSTi` versions in `requirements.txt`

The `plotly` version is old, and the reason for pinning it (pyGSTi) is not valid any more (#542) in more recent versions.

