### PR TITLE
add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,5 +23,5 @@ repos:
     rev: 'v1.5.6'  # Use the sha / tag you want to point at
     hooks:
     -   id: autopep8
-        args: [--max-line-length 120]
+        args: [--max-line-length=120]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+exclude: 'doc/conf.py'
+
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.12.0
+    hooks:
+    -   id: pyupgrade
+        # for now don't force to change from %-operator to {}
+        args: [--keep-percent-format, --py36-plus]
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    -   id: check-ast
+    -   id: check-builtin-literals
+    -   id: check-merge-conflict
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: mixed-line-ending
+    -   id: trailing-whitespace
+
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: 'v1.5.6'  # Use the sha / tag you want to point at
+    hooks:
+    -   id: autopep8
+        args: [--max-line-length 120]
+


### PR DESCRIPTION
Changes proposed in this pull request:
- Add pre-commit configuration file

@wvlothuizen The [pre-commit](https://pre-commit.com/) configuration add automatic formatting to all committed files using `autopep8` and `pyupgrade`. More tools can be added, see for example the config file for [qtt](https://github.com/QuTech-Delft/qtt/blob/dev/.pre-commit-config.yaml). For pycqed3 this initial configuration is quite conservative.


