### PR TITLE
Added function to return minimum readout hold-off including unit test.

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -955,6 +955,14 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
             'of the codewords. The valid range is 0 to 15.',
             vals=validators.Ints())
 
+        self.add_parameter(
+            'minimum_holdoff',
+            get_cmd=self._get_minimum_holdoff,
+            unit='s',
+            label='Minimum hold-off',
+            docstring='Returns the minimum allowed hold-off between two readout operations.',
+            vals=validators.Numbers())
+
     def _codeword_table_preamble(self, awg_nr) -> str:
         """
         Defines a snippet of code to use in the beginning of an AWG program in order to define the waveforms.
@@ -1073,6 +1081,14 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
 
     def _get_dio_calibration_delay(self):
         return self._dio_calibration_delay
+
+    def _get_minimum_holdoff(self):
+        if self.qas_0_result_averages() == 1:
+            holdoff = np.max((800, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
+        else:
+            holdoff = np.max((2560, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
+
+        return holdoff
 
     def _set_wait_dly(self, value) -> None:
         self.set('awgs_0_userregs_{}'.format(UHFQC.USER_REG_WAIT_DLY), value)

--- a/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
+++ b/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
@@ -120,6 +120,27 @@ class Test_UHFQC(unittest.TestCase):
     def test_print_overview(self):
         self.uhf.print_overview()
 
+    def test_minimum_holdoff(self):
+        # Test without averaging
+        self.uhf.qas_0_integration_length(128)
+        self.uhf.qas_0_result_averages(1)
+        self.uhf.qas_0_delay(0)
+        assert self.uhf.minimum_holdoff() == 800/1.8e9
+        self.uhf.qas_0_delay(896)
+        assert self.uhf.minimum_holdoff() == (896+16)/1.8e9
+        self.uhf.qas_0_integration_length(2048)
+        assert self.uhf.minimum_holdoff() == (2048)/1.8e9
+
+        # Test with averaging
+        self.uhf.qas_0_result_averages(16)
+        self.uhf.qas_0_delay(0)
+        self.uhf.qas_0_integration_length(128)
+        assert self.uhf.minimum_holdoff() == 2560/1.8e9
+        self.uhf.qas_0_delay(896)
+        assert self.uhf.minimum_holdoff() == 2560/1.8e9
+        self.uhf.qas_0_integration_length(4096)
+        assert self.uhf.minimum_holdoff() == 4096/1.8e9
+
     def test_reset_acquisition_params(self):
         self.uhf.awgs_0_userregs_0(100)
         self.uhf.awgs_0_userregs_15(153)


### PR DESCRIPTION
Fixes #191.

Changes proposed in this pull request:
- Added `minimum_holdoff` attribute to `UHFQuantumController` class.
- Added unit test of `minimum_holdoff` attribute.
- Attribute returns the minimum hold-off in units of seconds between two readout operations.

@chellings 

In order for the pull request to be merged, the following conditions must be met:
- test suite (Github actions) passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


