### PR TITLE
[RFC] autopep8

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/MinicircuitsRC.py
+++ b/pycqed/instrument_drivers/physical_instruments/MinicircuitsRC.py
@@ -10,45 +10,48 @@ from qcodes.utils import validators as vals
 
 from pyvisa import VisaIOError
 
+
 def dec_to_binstring(x, n=4):
- x = int(x)
- res = [1 if x & (1<<i) else 0 for i in range(n)]
- return res
+    x = int(x)
+    res = [1 if x & (1 << i) else 0 for i in range(n)]
+    return res
+
 
 def binstring_to_dec(s):
- return sum(int(b)*(1<<i) for i, b in enumerate(s))
+    return sum(int(b)*(1 << i) for i, b in enumerate(s))
+
 
 class MinicircuitsRFSwitch(VisaInstrument):
- '''
- Driver for Minicircuits RF switch
- '''
+    '''
+    Driver for Minicircuits RF switch
+    '''
 
- def __init__(self, name, address, **kwargs):
+    def __init__(self, name, address, **kwargs):
 
-     super().__init__(name, address, terminator="\n\r", **kwargs)
+        super().__init__(name, address, terminator="\n\r", **kwargs)
 
-     self.add_parameter("switch_setting",
-                        get_cmd="SWPORT?",
-                        set_cmd=self._set_switch,
-                        get_parser=dec_to_binstring,
-                        set_parser=binstring_to_dec,
-                        vals=vals.Anything())
+        self.add_parameter("switch_setting",
+                           get_cmd="SWPORT?",
+                           set_cmd=self._set_switch,
+                           get_parser=dec_to_binstring,
+                           set_parser=binstring_to_dec,
+                           vals=vals.Anything())
 
-     # the device sends a single '\n' as a hello, messing everything up...
-     self.visa_handle.read_termination = "\n"
-     try:
-         self.visa_handle.read_raw()
-     except VisaIOError as e:
-         print("Minicircuit Switch did not send telnet handshake")
-     self.visa_handle.read_termination = "\n\r"
+        # the device sends a single '\n' as a hello, messing everything up...
+        self.visa_handle.read_termination = "\n"
+        try:
+            self.visa_handle.read_raw()
+        except VisaIOError as e:
+            print("Minicircuit Switch did not send telnet handshake")
+        self.visa_handle.read_termination = "\n\r"
 
-     #this has to be read differently from the device. todo
-     #self.connect_message()
+        # this has to be read differently from the device. todo
+        # self.connect_message()
 
- def _set_switch(self, value):
-     """
-     The switch acknowledges switching by sending a 1,
-     so setting is a 'ask' process.
-     """
-     ret = self.ask("SETP={}".format(value))
-     assert ret=="1"
+    def _set_switch(self, value):
+        """
+        The switch acknowledges switching by sending a 1,
+        so setting is a 'ask' process.
+        """
+        ret = self.ask("SETP={}".format(value))
+        assert ret == "1"

--- a/pycqed/instrument_drivers/physical_instruments/QuTech/CC.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech/CC.py
@@ -13,7 +13,7 @@
 import logging
 import numpy as np
 import inspect
-from typing import Tuple,List
+from typing import Tuple, List
 
 from .CCCore import CCCore
 from pycqed.instrument_drivers.library.Transport import Transport
@@ -29,11 +29,11 @@ class CC(CCCore, Instrument, DIO.CalInterface):
     def __init__(self,
                  name: str,
                  transport: Transport,
-                 num_ccio: int=11,
+                 num_ccio: int = 11,
                  ccio_slots_driving_vsm: List[int] = None  # NB: default can not be '[]' because that is a mutable default argument
                  ) -> None:
-        super().__init__(name, transport) # calls CCCore
-        Instrument.__init__(self, name) # calls Instrument
+        super().__init__(name, transport)  # calls CCCore
+        Instrument.__init__(self, name)  # calls Instrument
 
         # user constants
         self._num_ccio = num_ccio  # the number of CCIO modules used
@@ -49,7 +49,6 @@ class CC(CCCore, Instrument, DIO.CalInterface):
 
         self._add_parameters(self._num_ccio)
         self._add_compatibility_parameters(self._num_ccio)
-
 
     ##########################################################################
     # QCoDeS parameter definitions
@@ -108,10 +107,10 @@ class CC(CCCore, Instrument, DIO.CalInterface):
                 label='Output Delay of DIO{}'.format(ccio),
                 docstring='This parameter determines the extra output delay introduced for the DIO{} channel (i.e. CCIO slot number)'.format(ccio),
                 unit='20 ns',
-                vals=vals.PermissiveInts(0, 31), # FIXME: CC limit is 2^32-1
+                vals=vals.PermissiveInts(0, 31),  # FIXME: CC limit is 2^32-1
                 set_cmd=_gen_set_func_1par(self._set_dio_delay, ccio)
-#                get_cmd=cmd + '?',
-                )
+                #                get_cmd=cmd + '?',
+            )
 
         # support for 'vsm_channel_delay{}' for CCL_Transmon.py::_set_mw_vsm_delay(), also see calibrate_mw_vsm_delay()
         # NB: CC supports 1/1200 MHz ~= 833 ps resolution
@@ -126,8 +125,8 @@ class CC(CCCore, Instrument, DIO.CalInterface):
                 unit='2.5 ns',
                 vals=vals.PermissiveInts(0, 127),
                 set_cmd=_gen_set_func_1par(self._set_vsm_channel_delay, vsm_ch)
-#                get_cmd=_gen_get_func_1par(self._get_vsm_channel_delay, vsm_ch),
-                )
+                #                get_cmd=_gen_get_func_1par(self._get_vsm_channel_delay, vsm_ch),
+            )
 
         # FIXME: num_append_pts not implemented, use vsm_fall_delay
 
@@ -186,7 +185,7 @@ class CC(CCCore, Instrument, DIO.CalInterface):
     # FIXME: move to CCCore? or CC_DIOCAL
     ##########################################################################
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0):
         # FIXME: does not match with uhfqa_prog, which requires single trigger
         cc_prog = inspect.cleandoc("""
         # program: UHFQA trigger program
@@ -199,11 +198,10 @@ class CC(CCCore, Instrument, DIO.CalInterface):
         self.assemble_and_start(cc_prog)
         self.calibrate_dio(port, expected_bits=dio_mask)
 
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
         # default return values
         expected_sequence = []
         dio_mask = 0x00000000
-
 
         if dio_mode == "awg8-mw-vsm" or dio_mode == 'microwave':  # 'new' QWG compatible microwave mode
             # based on ElecPrj_CC:src/q1asm/qwg_staircase.q1asm
@@ -240,7 +238,6 @@ class CC(CCCore, Instrument, DIO.CalInterface):
                                  (2, list(staircase_sequence)),
                                  (3, list(staircase_sequence))]
             dio_mask = 0x80FF80FF  # TRIG=0x8000000, TRIG_1=0x00008000, CWs=0x00FF00FF
-
 
         elif dio_mode == "awg8-mw-direct-iq" or dio_mode == "novsm_microwave":
 
@@ -288,7 +285,6 @@ class CC(CCCore, Instrument, DIO.CalInterface):
                                  (3, list(staircase_sequence))]
             dio_mask = 0x8F9F8F9F  # TRIG=0x8000000, TRIG_2=0x00008000, CWs=0x0F9F0F9F
 
-
         elif dio_mode == "awg8-flux" or dio_mode == "flux":
             # based on ZI_HDAWG8.py::_prepare_CC_dio_calibration_hdawg and examples/CC_examples/flux_calibration.vq1asm
             # FIXME: hardcoded slots, this is OpenQL output
@@ -311,9 +307,8 @@ class CC(CCCore, Instrument, DIO.CalInterface):
             expected_sequence = [(0, list(staircase_sequence + (staircase_sequence << 3))),
                                  (1, list(staircase_sequence + (staircase_sequence << 3))),
                                  (2, list(staircase_sequence + (staircase_sequence << 3))),
-                                 (3, list(staircase_sequence+ (staircase_sequence << 3)))]
+                                 (3, list(staircase_sequence + (staircase_sequence << 3)))]
             dio_mask = 0x8FFF8FFF
-
 
         elif dio_mode == "uhfqa":  # FIXME: no official mode yet
             # Based on UHFQuantumController.py::_prepare_CC_dio_calibration_uhfqa and  and examples/CC_examples/uhfqc_calibration.vq1asm
@@ -331,13 +326,15 @@ class CC(CCCore, Instrument, DIO.CalInterface):
         log.debug(f"uploading DIO calibration program for mode '{dio_mode}' to CC")
         self.assemble_and_start(cc_prog)
 
-        return dio_mask,expected_sequence
+        return dio_mask, expected_sequence
 
 ##########################################################################
 # helpers
 ##########################################################################
 
 # helpers for Instrument::add_parameter.set_cmd
+
+
 def _gen_set_func_1par(fun, par1):
     def set_func(val):
         return fun(par1, val)

--- a/pycqed/instrument_drivers/physical_instruments/QuTech/CCCore.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech/CCCore.py
@@ -71,7 +71,7 @@ class CCCore(SCPIBase):
         if len(program_string) > self.MAX_PROG_STR_LEN:
             raise RuntimeError('source program size {len(program_string)} exceeds maximum of {self.MAX_PROG_STR_LEN}')
 
-        hdr = 'QUTech:SEQuence:PROGram:ASSEMble ' # NB: include space as separator for binblock parameter
+        hdr = 'QUTech:SEQuence:PROGram:ASSEMble '  # NB: include space as separator for binblock parameter
         bin_block = program_string.encode('ascii')
         self.bin_block_write(bin_block, hdr)
 
@@ -188,19 +188,19 @@ class CCCore(SCPIBase):
     # HDAWG DIO/marker bit definitions: CC output
     HDAWG_TOGGLE_DS = 30
     HDAWG_TRIG = 31
-    HDAWG_CW = range(0,29)  # NB: bits used depend on mode
+    HDAWG_CW = range(0, 29)  # NB: bits used depend on mode
 
     # QWG DIO/marker bit definitions: CC output
     QWG_TOGGLE_DS = 30
     QWG_TRIG = 31
-    QWG1_CW = range(0,11)
-    QWG2_CW = range(16,27)
+    QWG1_CW = range(0, 11)
+    QWG2_CW = range(16, 27)
 
     # UHFQA DIO/marker bit definitions: CC output
     UHFQA_TOGGLE_DS = 31
     UHFQA_TRIG = 16
-    UHFQA_CW = range(17,26)
+    UHFQA_CW = range(17, 26)
 
     # UHFQA DIO/marker bit definitions: CC input
     UHFQA_DV = 0
-    UHFQA_RSLT = range(1,10)
+    UHFQA_RSLT = range(1, 10)

--- a/pycqed/instrument_drivers/physical_instruments/QuTech/QWG.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech/QWG.py
@@ -31,6 +31,8 @@ log = logging.getLogger(__name__)
 
 # Note: the HandshakeParameter is a temporary param that should be replaced
 # once qcodes issue #236 is closed
+
+
 class HandshakeParameter(Parameter):
 
     """
@@ -84,8 +86,8 @@ class QWG(QWGCore, Instrument):
                  name: str,
                  transport: Transport
                  ) -> None:
-        super().__init__(name, transport) # calls CCCore
-        Instrument.__init__(self, name) # calls Instrument
+        super().__init__(name, transport)  # calls CCCore
+        Instrument.__init__(self, name)  # calls Instrument
 
         # validator values
         self._dev_desc.mvals_trigger_impedance = vals.Enum(50),
@@ -167,7 +169,7 @@ class QWG(QWGCore, Instrument):
                 set_cmd=_gen_set_func_1par(self.get_offset, ch),
                 vals=vals.Numbers(-.25, .25),
                 get_parser=float,
-                docstring = f'Offset channel {ch}')
+                docstring=f'Offset channel {ch}')
 
             self.add_parameter(
                 f'ch{ch}_default_waveform',
@@ -191,7 +193,7 @@ class QWG(QWGCore, Instrument):
                 vals=self._dev_desc.mvals_trigger_level,
                 get_parser=float,
                 snapshot_exclude=True)
-                # FIXME: docstring
+            # FIXME: docstring
 
         # Single parameters
         self.add_parameter(
@@ -231,7 +233,6 @@ class QWG(QWGCore, Instrument):
         self._add_awg_parameters()
         self._add_codeword_parameters()
         self._add_dio_parameters()  # FIXME: conditional on QWG SW version?
-
 
     ##########################################################################
     # QCoDeS parameter definitions: codewords
@@ -280,7 +281,7 @@ class QWG(QWGCore, Instrument):
             set_cmd='DIO:MODE ' + '{}',
             vals=vals.Enum('MASTER', 'SLAVE'),
             val_mapping={'MASTER': 'MASter', 'SLAVE': 'SLAve'},
-            docstring=_dio_mode_doc + '\nEffective immediately when sent') # FIXME: no way, not a HandshakeParameter
+            docstring=_dio_mode_doc + '\nEffective immediately when sent')  # FIXME: no way, not a HandshakeParameter
 
         # FIXME: handle through SCPI status
         self.add_parameter(
@@ -293,7 +294,7 @@ class QWG(QWGCore, Instrument):
                       'Result:\n'
                       '\tTrue: DIO is calibrated\n'
                       '\tFalse: DIO is not calibrated'
-            )
+        )
 
         self.add_parameter(
             'dio_active_index',
@@ -305,8 +306,8 @@ class QWG(QWGCore, Instrument):
             vals=vals.Ints(0, 20),
             docstring='Get and set DIO calibration index\n'
                       'See dio_calibrate() parameter\n'
-                      'Effective immediately when sent' # FIXME: no way, not a HandshakeParameter
-            )
+                      'Effective immediately when sent'  # FIXME: no way, not a HandshakeParameter
+        )
 
     ##########################################################################
     # QCoDeS parameter helpers
@@ -443,6 +444,7 @@ def _gen_get_func_2par(fun, par1, par2):
 # Calibration with CC. FIXME: move out of driver
 ##########################################################################
 
+
 class QWGMultiDevices:
     """
     QWG helper class to execute parameters/functions on multiple devices. E.g.: DIO calibration
@@ -478,22 +480,22 @@ class QWGMultiDevices:
         CC_model = cc.IDN()['model']
         if 'QCC' in CC_model:
             qisa_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'QCC_DIO_Calibration.qisa')
+                                                  'QCC_DIO_Calibration.qisa')
             cs_qwg_dio_calibrate = os.path.join(_qwg_path, 'qcc_cs.txt')
             qisa_opcode_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'qcc_qisa_opcodes.qmap')
+                                                         'qcc_qisa_opcodes.qmap')
         if 'cc' in CC_model:
             qisa_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'QWG_DIO_Calibration.qisa')
+                                                  'QWG_DIO_Calibration.qisa')
             cs_qwg_dio_calibrate = os.path.join(_qwg_path, 'cs.txt')
             qisa_opcode_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'qisa_opcodes.qmap')
+                                                         'qisa_opcodes.qmap')
         elif 'CCL' in CC_model:
             qisa_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'QWG_DIO_Calibration.qisa')
+                                                  'QWG_DIO_Calibration.qisa')
             cs_qwg_dio_calibrate = os.path.join(_qwg_path, 'cs.txt')
             qisa_opcode_qwg_dio_calibrate = os.path.join(_qwg_path,
-                'qisa_opcodes.qmap')
+                                                         'qisa_opcodes.qmap')
         else:
             raise ValueError('CC model ({}) not recognized.'.format(CC_model))
 
@@ -535,6 +537,6 @@ class QWGMultiDevices:
                 print(f'QWG ({qwg.name}) calibration rapport\n{qwg.dio_calibration_rapport()}\n')
         cc.stop()
 
-        #Set the control store
+        # Set the control store
         cc.control_store(old_cs)
         cc.qisa_opcode(old_qisa_opcode)

--- a/pycqed/instrument_drivers/physical_instruments/QuTech/QWGCore.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech/QWGCore.py
@@ -90,7 +90,7 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         super().__init__(name, transport)
 
         # AWG properties
-        self._dev_desc = lambda:0  # create empty device descriptor
+        self._dev_desc = lambda: 0  # create empty device descriptor
         self._dev_desc.model = 'QWG'
         self._dev_desc.numChannels = 4
 #        self._dev_desc.numDacBits = 12
@@ -117,10 +117,10 @@ class QWGCore(SCPIBase, DIO.CalInterface):
                 # FIXME: we could be less rude and only disable the new parameters
                 # FIXME: let parameters depend on SW version, and on IORear type
                 log.warning(f"Incompatible driver version of QWG ({self.name}); The version ({version_cur[0]}."
-                                f"{version_cur[1]}.{version_cur[2]}) "
-                                f"of the QWG software is too old and not supported by this driver anymore. Some instrument "
-                                f"parameters will not operate and timeout. Please update the QWG software to "
-                                f"{version_min[0]}.{version_min[1]}.{version_min[2]} or later")
+                            f"{version_cur[1]}.{version_cur[2]}) "
+                            f"of the QWG software is too old and not supported by this driver anymore. Some instrument "
+                            f"parameters will not operate and timeout. Please update the QWG software to "
+                            f"{version_min[0]}.{version_min[1]}.{version_min[2]} or later")
                 self._dev_desc.numMaxCwBits = 7
                 self._dev_desc.numSelectCwInputs = 7
             self._dev_desc.numCodewords = pow(2, self._dev_desc.numSelectCwInputs)
@@ -151,7 +151,7 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         if block:
             self.get_operation_complete()
 
-        #self.check_errors()
+        # self.check_errors()
 
         # status = self.get_system_status()
         # warn_msg = self._detect_underdrive(status)
@@ -167,7 +167,7 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         if block:
             self.get_operation_complete()
 
-        #self.check_errors()
+        # self.check_errors()
 
     ##########################################################################
     #  Output functions (AWG5014 compatible)
@@ -184,7 +184,7 @@ class QWGCore(SCPIBase, DIO.CalInterface):
     ##########################################################################
 
     def set_amplitude(self, ch: int, amp: float) -> None:
-        self._transport.write(f'SOUR{ch}:VOLT:LEV:IMM:AMPL {amp:.6f}') #FIXME
+        self._transport.write(f'SOUR{ch}:VOLT:LEV:IMM:AMPL {amp:.6f}')  # FIXME
 
     def get_amplitude(self, ch: int) -> float:
         return self._ask_float(f'SOUR{ch}:VOLT:LEV:IMM:AMPL?')
@@ -399,7 +399,6 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         """
         return self._int_to_array(self._ask('DIO:INDexes?'))
 
-
     def dio_calibrated_inputs(self) -> int:
         """
         'Get all DIO inputs which are calibrated\n'
@@ -422,7 +421,7 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         """
         return bool(self._ask_int('DIO:IB?'))
 
-    def dio_calibration_report(self, extended: bool=False) -> str:
+    def dio_calibration_report(self, extended: bool = False) -> str:
         """
         Return a string containing the latest DIO calibration report (successful and failed calibrations). Includes:
         selected index, dio mode, valid indexes, calibrated DIO bits and the DIO bitDiff table.
@@ -464,7 +463,6 @@ class QWGCore(SCPIBase, DIO.CalInterface):
         """
         return self._ask_int(f'QUTEch:TRIGgers{ch}:LOGIcinput?')
 
-
     def set_bitmap(self, ch: int) -> None:
         """
         Codeword bit map for a channel, 14 bits available of which 10 are selectable.
@@ -478,15 +476,14 @@ class QWGCore(SCPIBase, DIO.CalInterface):
     def get_bitmap(self, ch: int) -> List:
         return self._int_to_array(self._ask(f'DAC{ch}:BITmap?'))
 
-
     ##########################################################################
     # overrides for CalInterface interface
     ##########################################################################
 
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
         raise RuntimeError("QWG cannot output calibration data")
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0) -> None:
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0) -> None:
         self.dio_calibrate()    # FIXME: integrate
 
     ##########################################################################

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_AWG_Module.py
@@ -218,7 +218,7 @@ class QuTech_AWG_Module(SCPI):
                                get_cmd=self._gen_ch_get_func(
                                     self._getMatrix, ch_pair),
                                set_cmd=self._gen_ch_set_func(
-                                    self._setMatrix, ch_pair),
+                                   self._setMatrix, ch_pair),
                                # NB range is not a hardware limit
                                vals=vals.Arrays(-2, 2, shape=(2, 2)),
                                docstring='Q & I transformation per channel pair.\n'
@@ -750,7 +750,7 @@ class QuTech_AWG_Module(SCPI):
         """
         self.write(f'DIO:CALibrate {target_index}')
 
-    def dio_calibration_rapport(self, extended: bool=False) -> str:
+    def dio_calibration_rapport(self, extended: bool = False) -> str:
         """
         Return a string containing the latest DIO calibration rapport (successful and failed calibrations). Includes:
         selected index, dio mode, valid indexes, calibrated DIO bits and the DIO bitDiff table.
@@ -1088,6 +1088,7 @@ class QWGMultiDevices:
     QWG helper class to execute parameters/functions on multiple devices. E.g.: DIO calibration
     Usually all methods are static
     """
+
     def __init__(self, qwgs: List[QuTech_AWG_Module]) -> None:
         self.qwgs = qwgs
 
@@ -1095,7 +1096,7 @@ class QWGMultiDevices:
     def dio_calibration(cc, qwgs: List[QuTech_AWG_Module], verbose: bool = False):
         raise DeprecationWarning("calibrate_CC_dio_protocol is deprecated, use instrument_drivers.library.DIO.calibrate")
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0):
         """
         Calibrate multiple QWG using a CCLight, QCC or other CC-like devices
         First QWG will be used als base DIO calibration for all other QWGs. First QWG in the list needs to be a DIO
@@ -1193,7 +1194,7 @@ class Mock_QWG(QuTech_AWG_Module):
         # self.connect_message()
 
     def add_parameter(self, name: str,
-                      parameter_class: type=Parameter, **kwargs) -> None:
+                      parameter_class: type = Parameter, **kwargs) -> None:
 
         kwargs.pop('get_cmd', None)
         kwargs.pop('set_cmd', None)

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_CCL.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_CCL.py
@@ -20,7 +20,7 @@ import json
 import array
 import numpy as np
 from collections import OrderedDict
-from typing import Tuple,List
+from typing import Tuple, List
 
 from .SCPI import SCPI
 from ._CCL.CCLightMicrocode import CCLightMicrocode
@@ -53,6 +53,7 @@ CHAR_MAX = +127
 CHAR_MIN = -128
 
 MAX_NUM_INSN = 2**15
+
 
 class CCL(SCPI, DIO.CalInterface):
     """
@@ -244,7 +245,7 @@ class CCL(SCPI, DIO.CalInterface):
             open_file_success = True
         except Exception as e:
             log.info("CC-Light local parameter file {} not found ({})".format(
-                            self.param_file_name, e))
+                self.param_file_name, e))
 
         read_file_success = False
         if open_file_success:
@@ -254,7 +255,7 @@ class CCL(SCPI, DIO.CalInterface):
                 read_file_success = True
             except Exception as e:
                 log.info("Error while reading CC-Light local parameter file."
-                        " Will update it from the hardware.")
+                         " Will update it from the hardware.")
 
         if read_file_success:
             self.saved_param_version = None
@@ -265,20 +266,20 @@ class CCL(SCPI, DIO.CalInterface):
             # check if the saved parameters have the same version number
             # as CC-Light, if yes, return the saved one.
             if (('Embedded Software Build Time' in self.version_info and
-                  (self.version_info['Embedded Software Build Time'] ==
+                 (self.version_info['Embedded Software Build Time'] ==
                   self.saved_param_version)) or
-                self._dummy_instr):
+                    self._dummy_instr):
                 results = file_content["parameters"]
                 return results
             else:
                 log.info("CC-Light local parameter file out of date."
-                    " Will update it from the hardware.")
+                         " Will update it from the hardware.")
 
         try:
             raw_param_string = self.ask('QUTech:PARAMeters?')
         except Exception as e:
             raise ValueError("Failed to retrieve parameter information"
-                " from CC-Light hardware: ", e)
+                             " from CC-Light hardware: ", e)
 
         raw_param_string = raw_param_string.replace('\t', '\n')
 
@@ -286,7 +287,7 @@ class CCL(SCPI, DIO.CalInterface):
             results = json.loads(raw_param_string)["parameters"]
         except Exception as e:
             raise ValueError("Unrecognized parameter information received from "
-                "CC-Light: \n {}".format(raw_param_string))
+                             "CC-Light: \n {}".format(raw_param_string))
 
         try:
             # file.write(raw_param_string)
@@ -294,7 +295,7 @@ class CCL(SCPI, DIO.CalInterface):
             param_dict = json.loads(raw_param_string)
             file = open(self.param_file_name, 'w')
             par_str = json.dumps(param_dict,
-                                  indent=4, sort_keys=True)
+                                 indent=4, sort_keys=True)
             file.write(par_str)
             file.close()
         except Exception as e:
@@ -330,7 +331,7 @@ class CCL(SCPI, DIO.CalInterface):
     def print_control_store(self):
         if self.microcode is None:
             log.info("The microcode unit of CCLight has not been"
-                " initialized yet.")
+                     " initialized yet.")
             return
 
         self.microcode.dump_microcode()
@@ -338,7 +339,7 @@ class CCL(SCPI, DIO.CalInterface):
     def print_qisa_with_control_store(self):
         if self.microcode is None:
             log.info("The microcode unit of CCLight has not been"
-                " initialized yet.")
+                     " initialized yet.")
             return
 
         if self.QISA is None:
@@ -349,7 +350,7 @@ class CCL(SCPI, DIO.CalInterface):
 
         insn_opcodes_str = self.QISA.dumpInstructionsSpecification()
         lines = insn_opcodes_str.split('\n')
-        trimed_lines = [line.strip() for line in lines \
+        trimed_lines = [line.strip() for line in lines
                         if line.startswith('def_q')]
 
         # put every instruction with its opcode into a dict
@@ -378,7 +379,7 @@ class CCL(SCPI, DIO.CalInterface):
 
         print("Instruction      Codewords")
         for key, value in q_arg.items():
-            print('  {:<10s}:  '.format(key), end = '')
+            print('  {:<10s}:  '.format(key), end='')
             self.microcode.print_cs_line_no_header(value)
             print("")
 
@@ -423,10 +424,9 @@ class CCL(SCPI, DIO.CalInterface):
 
         if len(intarray) > MAX_NUM_INSN:
             raise OverflowError("Failed to upload instructions: program length ({})"
-                " exceeds allowed maximum value ({}).".format(len(intarray),
-                    MAX_NUM_INSN))
+                                " exceeds allowed maximum value ({}).".format(len(intarray),
+                                                                              MAX_NUM_INSN))
             return
-
 
         binBlock = bytearray(array.array('L', intarray))
         # print("binblock size:", len(binBlock))
@@ -464,7 +464,7 @@ class CCL(SCPI, DIO.CalInterface):
     def _upload_opcode_qmap(self, filename: str):
         success = self.QISA.loadQuantumInstructions(filename)
         if not success:
-            #logging.warning("Error: ", driver.getLastErrorMessage())  FIXME: invalid code
+            # logging.warning("Error: ", driver.getLastErrorMessage())  FIXME: invalid code
             logging.warning("Failed to load quantum instructions from dictionaries.")
 
         return success
@@ -499,22 +499,22 @@ class CCL(SCPI, DIO.CalInterface):
         """Configures a CCL with a default program that generates data suitable for DIO calibration.
         Also starts the program."""
         cs_filepath = os.path.join(pycqed.__path__[0],
-                'measurement',
-                'openql_experiments',
-                'output', 'cs.txt')
+                                   'measurement',
+                                   'openql_experiments',
+                                   'output', 'cs.txt')
 
         opc_filepath = os.path.join(pycqed.__path__[0],
-                'measurement',
-                'openql_experiments',
-                'output', 'qisa_opcodes.qmap')
+                                    'measurement',
+                                    'openql_experiments',
+                                    'output', 'qisa_opcodes.qmap')
 
         self.control_store(cs_filepath)
         self.qisa_opcode(opc_filepath)
 
         test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..',
-                'examples','CCLight_example',
-                'qisa_test_assembly','calibration_cws_ro.qisa'))
+                                               '..',
+                                               'examples', 'CCLight_example',
+                                               'qisa_test_assembly', 'calibration_cws_ro.qisa'))
 
         # Start the CCL with the program configured above
         self.eqasm_program(test_fp)
@@ -541,17 +541,18 @@ class CCL(SCPI, DIO.CalInterface):
             (TODO add support for microwave on DIO5)
         """
         log.info('Calibrating DIO delays')
-        if verbose: print("Calibrating DIO delays")
+        if verbose:
+            print("Calibrating DIO delays")
 
         cs_filepath = os.path.join(pycqed.__path__[0],
-            'measurement',
-            'openql_experiments',
-            'output', 'cs.txt')
+                                   'measurement',
+                                   'openql_experiments',
+                                   'output', 'cs.txt')
 
         opc_filepath = os.path.join(pycqed.__path__[0],
-            'measurement',
-            'openql_experiments',
-            'output', 'qisa_opcodes.qmap')
+                                    'measurement',
+                                    'openql_experiments',
+                                    'output', 'qisa_opcodes.qmap')
 
         # Configure CCL
         self.control_store(cs_filepath)
@@ -559,26 +560,26 @@ class CCL(SCPI, DIO.CalInterface):
 
         if self.cfg_codeword_protocol() == 'flux':
             test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..',
-                'examples','CCLight_example',
-                'qisa_test_assembly','calibration_cws_flux.qisa'))
+                                                   '..',
+                                                   'examples', 'CCLight_example',
+                                                   'qisa_test_assembly', 'calibration_cws_flux.qisa'))
 
             sequence_length = 8
             staircase_sequence = np.arange(1, sequence_length)
-            expected_sequence = [(0, list(staircase_sequence + (staircase_sequence << 3))), \
-                                 (1, list(staircase_sequence + (staircase_sequence << 3))), \
-                                 (2, list(staircase_sequence + (staircase_sequence << 3))), \
+            expected_sequence = [(0, list(staircase_sequence + (staircase_sequence << 3))),
+                                 (1, list(staircase_sequence + (staircase_sequence << 3))),
+                                 (2, list(staircase_sequence + (staircase_sequence << 3))),
                                  (3, list(staircase_sequence))]
         elif self.cfg_codeword_protocol() == 'microwave':
             test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..','examples','CCLight_example',
-                'qisa_test_assembly','calibration_cws_mw.qisa'))
+                                                   '..', 'examples', 'CCLight_example',
+                                                   'qisa_test_assembly', 'calibration_cws_mw.qisa'))
 
             sequence_length = 32
             staircase_sequence = np.arange(1, sequence_length)
-            expected_sequence = [(0, list(reversed(staircase_sequence))), \
-                                 (1, list(reversed(staircase_sequence))), \
-                                 (2, list(reversed(staircase_sequence))), \
+            expected_sequence = [(0, list(reversed(staircase_sequence))),
+                                 (1, list(reversed(staircase_sequence))),
+                                 (2, list(reversed(staircase_sequence))),
                                  (3, list(reversed(staircase_sequence)))]
 
         else:
@@ -593,8 +594,8 @@ class CCL(SCPI, DIO.CalInterface):
     # overrides for CalInterface interface
     ##########################################################################
 
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
-        if port==3 or port==4:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
+        if port == 3 or port == 4:
             # FIXME: incomplete port assumptions
             self._prepare_CCL_dio_calibration_hdawg()
         else:

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_QCC.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_QCC.py
@@ -17,7 +17,7 @@ import json
 import array
 import numpy as np
 from collections import OrderedDict
-from typing import Tuple,List
+from typing import Tuple, List
 
 from .SCPI import SCPI
 from ._QCC.QCCMicrocode import QCCMicrocode
@@ -531,22 +531,22 @@ class QCC(SCPI, DIO.CalInterface):
         """Configures a QCC with a default program that generates data suitable for DIO calibration. Also starts the QCC."""
 
         cs_filepath = os.path.join(pycqed.__path__[0],
-                'measurement',
-                'openql_experiments',
-                's17', 'cs.txt')
+                                   'measurement',
+                                   'openql_experiments',
+                                   's17', 'cs.txt')
 
         opc_filepath = os.path.join(pycqed.__path__[0],
-                'measurement',
-                'openql_experiments',
-                's17', 'qisa_opcodes.qmap')
+                                    'measurement',
+                                    'openql_experiments',
+                                    's17', 'qisa_opcodes.qmap')
 
         self.control_store(cs_filepath)
         self.qisa_opcode(opc_filepath)
 
         test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..',
-                'examples','QCC_example',
-                'qisa_test_assembly','ro_calibration.qisa'))
+                                               '..',
+                                               'examples', 'QCC_example',
+                                               'qisa_test_assembly', 'ro_calibration.qisa'))
 
         # Start the QCC with the program configured above
         self.stop()
@@ -569,17 +569,18 @@ class QCC(SCPI, DIO.CalInterface):
             (TODO add support for microwave on DIO5)
         """
         log.info('Calibrating DIO delays')
-        if verbose: print("Calibrating DIO delays")
+        if verbose:
+            print("Calibrating DIO delays")
 
         cs_filepath = os.path.join(pycqed.__path__[0],
-            'measurement',
-            'openql_experiments',
-            's17', 'cs.txt')
+                                   'measurement',
+                                   'openql_experiments',
+                                   's17', 'cs.txt')
 
         opc_filepath = os.path.join(pycqed.__path__[0],
-            'measurement',
-            'openql_experiments',
-            's17', 'qisa_opcodes.qmap')
+                                    'measurement',
+                                    'openql_experiments',
+                                    's17', 'qisa_opcodes.qmap')
 
         # Configure QCC
         self.control_store(cs_filepath)
@@ -588,46 +589,45 @@ class QCC(SCPI, DIO.CalInterface):
         # FIXME: self=HDAWG
         if self.cfg_codeword_protocol() == 'flux':
             test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..',
-                'examples','QCC_example',
-                'qisa_test_assembly','flux_calibration.qisa'))
+                                                   '..',
+                                                   'examples', 'QCC_example',
+                                                   'qisa_test_assembly', 'flux_calibration.qisa'))
 
             sequence_length = 8
             staircase_sequence = np.arange(1, sequence_length)
 
             # expected sequence should be ([9, 18, 27, 36, 45, 54, 63])
-            expected_sequence = [(0, list(staircase_sequence + (staircase_sequence << 3))), \
-                                 (1, list(staircase_sequence + (staircase_sequence << 3))), \
-                                 (2, list(staircase_sequence + (staircase_sequence << 3))), \
-                                 (3, list(staircase_sequence+ (staircase_sequence << 3)))]
+            expected_sequence = [(0, list(staircase_sequence + (staircase_sequence << 3))),
+                                 (1, list(staircase_sequence + (staircase_sequence << 3))),
+                                 (2, list(staircase_sequence + (staircase_sequence << 3))),
+                                 (3, list(staircase_sequence + (staircase_sequence << 3)))]
 
         elif self.cfg_codeword_protocol() == 'microwave':
 
             test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..',
-                'examples','QCC_example',
-                'qisa_test_assembly','withvsm_calibration.qisa'))
+                                                   '..',
+                                                   'examples', 'QCC_example',
+                                                   'qisa_test_assembly', 'withvsm_calibration.qisa'))
 
             sequence_length = 32
             staircase_sequence = range(1, sequence_length)
-            expected_sequence =  [(0, list(staircase_sequence)), \
-                                 (1, list(staircase_sequence)), \
-                                 (2, list(reversed(staircase_sequence))), \
+            expected_sequence = [(0, list(staircase_sequence)),
+                                 (1, list(staircase_sequence)),
+                                 (2, list(reversed(staircase_sequence))),
                                  (3, list(reversed(staircase_sequence)))]
-
 
         elif self.cfg_codeword_protocol() == 'new_novsm_microwave':
 
             test_fp = os.path.abspath(os.path.join(pycqed.__path__[0],
-                '..','examples','QCC_example',
-                'qisa_test_assembly','novsm_calibration.qisa'))
+                                                   '..', 'examples', 'QCC_example',
+                                                   'qisa_test_assembly', 'novsm_calibration.qisa'))
 
             sequence_length = 32
             staircase_sequence = range(1, sequence_length)
-            expected_sequence = [(0, list(staircase_sequence)), \
-                                 (1, list(reversed(staircase_sequence))), \
-                                 (2, list(staircase_sequence)), \
-                                 (3, list(reversed(staircase_sequence))) ]
+            expected_sequence = [(0, list(staircase_sequence)),
+                                 (1, list(reversed(staircase_sequence))),
+                                 (2, list(staircase_sequence)),
+                                 (3, list(reversed(staircase_sequence)))]
 
         else:
             raise RuntimeError("Can only calibrate DIO protocol for 'flux' or 'microwave' mode!")
@@ -641,14 +641,14 @@ class QCC(SCPI, DIO.CalInterface):
     # overrides for CalInterface interface
     ##########################################################################
 
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
-        if port==3 or port==4:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
+        if port == 3 or port == 4:
             # FIXME: incomplete port assumptions
             self._prepare_QCC_dio_calibration_hdawg()
         else:
             self._prepare_QCC_dio_calibration_uhfqa()
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0):
         raise RuntimeError("not implemented")
 
 

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_SPI_S4g_FluxCurrent.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_SPI_S4g_FluxCurrent.py
@@ -12,7 +12,7 @@ from pycqed.analysis.tools.plotting import SI_prefix_and_scale_factor
 
 class QuTech_SPI_S4g_FluxCurrent(Instrument):
     def __init__(self, name: str, address: str,
-                 channel_map: dict, reset_currents: bool=False):
+                 channel_map: dict, reset_currents: bool = False):
         """
         Create an instance of the SPI S4g FluxCurrent instrument.
 

--- a/pycqed/instrument_drivers/physical_instruments/QuTech_VSM_Module.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech_VSM_Module.py
@@ -135,7 +135,7 @@ class QuTechVSMModule(SCPI):
         # Marker breakout board
         self.add_parameter('mbbc_state',
                            docstring='Whether the _marker breakout board_ is '
-                                    'connected to the VSM.',
+                           'connected to the VSM.',
                            get_cmd='MBBC?',
                            vals=validators.Enum('connected', 'disconnected'))
 
@@ -195,13 +195,13 @@ class QuTechVSMModule(SCPI):
         # been set correctly in the VSM in order to correctly use the
         # orthogonalized parameters
         self.add_parameter(
-                            'getCalibrationDataAvailable',
-                            docstring='Use this to check if the calibration data has been '\
-                                      'set correctly in the VSM. Outputs an integer 0 (False), 1 (True)',
-                            get_cmd='CALIBRATIONDATAPATH' + '?',
-                            get_parser=int,
-                            vals=validators.Ints(0,1)
-                        )
+            'getCalibrationDataAvailable',
+            docstring='Use this to check if the calibration data has been '
+            'set correctly in the VSM. Outputs an integer 0 (False), 1 (True)',
+            get_cmd='CALIBRATIONDATAPATH' + '?',
+            get_parser=int,
+            vals=validators.Ints(0, 1)
+        )
 
         # Raw attenuationa and phase
         #  Two input pulses
@@ -295,7 +295,7 @@ class QuTechVSMModule(SCPI):
                                        set_cmd=scpi_name + ' {}',
                                        unit='deg',
                                        get_parser=float,
-                                       vals=validators.Numbers(-125,45))
+                                       vals=validators.Numbers(-125, 45))
 
     def _sync_time_and_add_parameter(self):
         doc_description = 'Parameter to sync the time from user computer to VSM'
@@ -306,9 +306,9 @@ class QuTechVSMModule(SCPI):
         current_time_str = datetime.now().strftime('%YT%mT%dT%HT%MT%S')
         self.sync_time(current_time_str)
 
-    def snapshot_base(self, update: bool=False,
-                      params_to_skip_update =None, 
-                      params_to_exclude = None ):
+    def snapshot_base(self, update: bool = False,
+                      params_to_skip_update=None,
+                      params_to_exclude=None):
         """
         State of the instrument as a JSON-compatible dict.
         Args:
@@ -322,8 +322,7 @@ class QuTechVSMModule(SCPI):
             dict: base snapshot
         """
 
-
-        if params_to_exclude is None: 
+        if params_to_exclude is None:
             params_to_exclude = self._params_to_exclude
 
         snap = {
@@ -337,7 +336,7 @@ class QuTechVSMModule(SCPI):
         snap['parameters'] = {}
         for name, param in self.parameters.items():
             if params_to_exclude and name in params_to_exclude:
-                pass 
+                pass
             elif params_to_skip_update and name in params_to_skip_update:
                 update_par = False
             else:
@@ -352,6 +351,7 @@ class QuTechVSMModule(SCPI):
             if hasattr(self, attr):
                 snap[attr] = getattr(self, attr)
         return snap
+
 
 class Dummy_QuTechVSMModule(QuTechVSMModule):
 

--- a/pycqed/instrument_drivers/physical_instruments/RIGOL_DS4043.py
+++ b/pycqed/instrument_drivers/physical_instruments/RIGOL_DS4043.py
@@ -114,15 +114,14 @@ class RIGOL_DS4043(VisaInstrument):
         '''
         super().__init__(name, address, **kwargs)
 
-
         # logging.info(__name__ + ' : Initializing instrument')
         # Instrument.__init__(self, name, tags=['physical', 'source'])
-        self._trig_modes = ['EDGE', 'PULS', 'SLOP','VID', 'PATT', 'RS232',
-            'IIC','SPI', 'CAN', 'FLEX', 'USB']
+        self._trig_modes = ['EDGE', 'PULS', 'SLOP', 'VID', 'PATT', 'RS232',
+                            'IIC', 'SPI', 'CAN', 'FLEX', 'USB']
         self._trig_sources = ['CHAN1', 'CHAN2', 'CHAN3', 'CHAN4',
-            'EXT', 'EXT5', 'ACL']# also D0 - D15
+                              'EXT', 'EXT5', 'ACL']  # also D0 - D15
         self._measure_modes = ['VAVG']
-        self._measurment_par = ['SAV','SCUR','SDEV','SMAX','SMIN']
+        self._measurment_par = ['SAV', 'SCUR', 'SDEV', 'SMAX', 'SMIN']
         self._channels = ['CHAN1', 'CHAN2', 'CHAN3', 'CHAN4']
 
         self._address = address
@@ -133,66 +132,66 @@ class RIGOL_DS4043(VisaInstrument):
         # else:
         #     self._visainstrument = visa.instrument(address, timeout=2)
         self.add_parameter('sample_rate',
-            get_cmd='ACQ:SRAT?',
-            get_parser=float,
-            unit='Hz')
+                           get_cmd='ACQ:SRAT?',
+                           get_parser=float,
+                           unit='Hz')
         self.add_parameter('trigger_mode',
-            get_cmd=':TRIG:MODE?',
-            get_parser=str,
-            set_cmd=self._set_trigger_mode)
+                           get_cmd=':TRIG:MODE?',
+                           get_parser=str,
+                           set_cmd=self._set_trigger_mode)
         self.add_parameter('trigger_level',
-            get_cmd=lambda: self._get_trig_func_par_value(
-                                self.trigger_mode(),
-                                'LEV'),
-            get_parser=float,
-            set_cmd=lambda s: self._set_trig_func_par_value(
-                                self.trigger_mode(),
-                                'LEV',s),
-            unit='V')
+                           get_cmd=lambda: self._get_trig_func_par_value(
+                               self.trigger_mode(),
+                               'LEV'),
+                           get_parser=float,
+                           set_cmd=lambda s: self._set_trig_func_par_value(
+                               self.trigger_mode(),
+                               'LEV', s),
+                           unit='V')
         self.add_parameter('trigger_source',
-            get_cmd= lambda:_get_trig_func_par(self.trigger_mode(),
-                                               'SOUR'),
-            get_parser= str,
-            set_cmd=self._set_trigger_source,
-            unit='')
+                           get_cmd=lambda: _get_trig_func_par(self.trigger_mode(),
+                                                              'SOUR'),
+                           get_parser=str,
+                           set_cmd=self._set_trigger_source,
+                           unit='')
         self.add_parameter('timebase_offset',
-            get_cmd='TIM:OFFS?',
-            get_parser=float,
-            set_cmd='TIM:OFFS {:f}',
-            unit='s')
+                           get_cmd='TIM:OFFS?',
+                           get_parser=float,
+                           set_cmd='TIM:OFFS {:f}',
+                           unit='s')
         self.add_parameter('timebase_scale',
-            get_cmd='TIM:SCAL?',
-            get_parser=float,
-            set_cmd='TIM:SCAL {:f}',
-            unit='s')
+                           get_cmd='TIM:SCAL?',
+                           get_parser=float,
+                           set_cmd='TIM:SCAL {:f}',
+                           unit='s')
         self.add_parameter('measure_mode',
-            get_cmd='TRIG:MODE?',
-            get_parser=str,
-            set_cmd='TIM:SCAL {:f}',
-            unit='s')
+                           get_cmd='TRIG:MODE?',
+                           get_parser=str,
+                           set_cmd='TIM:SCAL {:f}',
+                           unit='s')
         self.add_parameter('measurement_source',
-            get_cmd='MEAS:SOUR?',
-            get_parser=str,
-            set_cmd=self._set_measurement_source,
-            unit='')
+                           get_cmd='MEAS:SOUR?',
+                           get_parser=str,
+                           set_cmd=self._set_measurement_source,
+                           unit='')
         # self.add_parameter('measurement',
         #     flags=Instrument.FLAG_GET,
         #     type=types.FloatType)
         self.add_parameter('current_channel',
-            get_cmd='WAV:SOUR?',
-            get_parser=str,
-            set_cmd=self._set_current_channel,
-            unit='')
+                           get_cmd='WAV:SOUR?',
+                           get_parser=str,
+                           set_cmd=self._set_current_channel,
+                           unit='')
         # self.add_parameter('read_waveform',
         #     type=types.ListType,
         #     flags=Instrument.FLAG_GET, unit='AU',
         #     tags=['measure'])
 
         self.add_parameter('no_points',
-            get_cmd='WAV:POIN?',
-            get_parser=int,
-            set_cmd='WAV:POIN {:d}' ,
-            unit='')
+                           get_cmd='WAV:POIN?',
+                           get_parser=int,
+                           set_cmd='WAV:POIN {:d}',
+                           unit='')
         # self.add_parameter(
         #     'Navg', type=types.IntType, flags=Instrument.FLAG_GETSET,
         #     minval=1, maxval=8192, unit='s')
@@ -210,11 +209,6 @@ class RIGOL_DS4043(VisaInstrument):
         # self._visainstrument.write(':RUN\n')
         # self._visainstrument.write(':AUT\n')
 
-
-
-
-
-
     # parameter functions
     # def do_set_timebase_offset(self, val):
     #     self._visainstrument.write('TIM:OFFS %s'%val)
@@ -226,7 +220,6 @@ class RIGOL_DS4043(VisaInstrument):
     # def do_set_timebase_scale(self,val):
     #     self._visainstrument.write('TIM:SCAL %s'%val)
 
-
     # def do_get_timebase_scale(self):
     #     ans = self._visainstrument.ask('TIM:SCAL?')
     #     return ans
@@ -237,8 +230,6 @@ class RIGOL_DS4043(VisaInstrument):
             self.write(':TRIG:%s' % mode)
         else:
             raise ValueError('invalid mode %s' % mode)
-
-
 
     # def do_set_trigger_level(self, level, mode):
     #     self._set_trig_func_par_value(mode, 'LEV', level)
@@ -252,7 +243,6 @@ class RIGOL_DS4043(VisaInstrument):
             self._set_trig_func_par_value(mode, 'SOUR', source)
         else:
             raise ValueError('invalid mode %s' % mode)
-
 
     # def do_get_trigger_source(self,mode=None):
     #     return self._get_trig_func_par(mode,'SOUR')
@@ -268,9 +258,9 @@ class RIGOL_DS4043(VisaInstrument):
     #     ans = self._visainstrument.ask('WAV:SOUR?')
     #     return ans
 
-    def _set_current_channel(self,val):
+    def _set_current_channel(self, val):
         if val in self._channels:
-            self.write('WAV:SOUR %s'%val)
+            self.write('WAV:SOUR %s' % val)
         else:
             raise ValueError('invalid channel %s' % val)
 
@@ -287,12 +277,10 @@ class RIGOL_DS4043(VisaInstrument):
 
     def _set_measurement_source(self, source, mode=None):
         if source in self._trig_sources:
-            self.write('MEAS:SOUR %s'%source)
+            self.write('MEAS:SOUR %s' % source)
 
         else:
             raise ValueError('invalid source %s' % mode)
-
-
 
     # def do_get_measurement_source(self,mode=None):
     #     return self._visainstrument.ask('MEAS:SOUR?')
@@ -313,7 +301,6 @@ class RIGOL_DS4043(VisaInstrument):
     #     logging.debug('Read current value')
     #     text = self._visainstrument.ask('WAV:DATA?')
     #     return np.double(text.split(',')[:-1])
-
 
     # def reset(self):
     #     self._visainstrument.write(':CLE\n')
@@ -377,8 +364,8 @@ class RIGOL_DS4043(VisaInstrument):
         mode = self._determine_mode(mode)
         string = ':TRIG:%s:%s?' % (mode, par)
         ans = self._visainstrument.ask(string)
-        logging.debug('ask instrument for %s (result %s)' % \
-            (string, ans))
+        logging.debug('ask instrument for %s (result %s)' %
+                      (string, ans))
         return ans
 
 ##################
@@ -421,9 +408,6 @@ class RIGOL_DS4043(VisaInstrument):
     #     return ans
 
 
-
-
-
 ##################
 ### Important! ###
 ##################
@@ -431,12 +415,11 @@ class RIGOL_DS4043(VisaInstrument):
 ### Important! ###
 ##################
 
+    # Ramiro stuff used for the rabi simulations: This can go away with their approval
 
-
-    #Ramiro stuff used for the rabi simulations: This can go away with their approval
-    def read_channels(self,channel_list):
+    def read_channels(self, channel_list):
         self.visawrite(':ACQuire:SRATe?\n')
-        srate = self.sample_rate() #np.double(self.visaread())
+        srate = self.sample_rate()  # np.double(self.visaread())
         data = []
         x_axis = []
         self.prepare_for_readwfm()
@@ -447,7 +430,7 @@ class RIGOL_DS4043(VisaInstrument):
             # self.visawrite(':ACQuire:MDEPth?\n')
             # npoints = np.double(self.visaread())
             ch_out = [0]
-            while(len(ch_out)<13):
+            while(len(ch_out) < 13):
                 # print 'blah'
                 ch = self.readwfm(channel)
                 # print ch
@@ -455,7 +438,7 @@ class RIGOL_DS4043(VisaInstrument):
             # print splitted_var[-1]
             # ch_out = np.array(splitted_var, dtype=np.double)
             # print ch_out.shape
-            step_size = 1./srate#config_parameters[4]*config_parameters[2]/npoints
+            step_size = 1./srate  # config_parameters[4]*config_parameters[2]/npoints
             # start_t = np.double(self.visaread())
 
             # Still dont undestand the scaling of 2*ste_size, we just choose it
@@ -465,7 +448,7 @@ class RIGOL_DS4043(VisaInstrument):
             x_axis.append(axis)
             data.append(ch_out)
 
-        return x_axis,data
+        return x_axis, data
 
     # def prepare_for_readwfm(self):
 
@@ -493,8 +476,7 @@ class RIGOL_DS4043(VisaInstrument):
         buff = (ct.c_ubyte*buff_size)()
         # wfmBuf = (ct. c_char * len(buff)).from_buffer(buff)
 
-        self.visawrite(':WAV:SOURce CHAN%s\n'% channel)
-
+        self.visawrite(':WAV:SOURce CHAN%s\n' % channel)
 
         # self._visainstrument.write(':WAV:RESet\n')
         self._visainstrument.write(':WAV:BEGin\n')
@@ -502,7 +484,7 @@ class RIGOL_DS4043(VisaInstrument):
         reading = True
 
         status = self._visainstrument.read()
-        while (reading and readTim<1):
+        while (reading and readTim < 1):
             if status is 'I':
                 self._visainstrument.write(':WAV:DATA?\n')
                 var = self._visainstrument.read()
@@ -535,8 +517,6 @@ class RIGOL_DS4043(VisaInstrument):
         self._visainstrument.write(':WAV:END\n')
         # self._visainstrument.write(':RUN\n')
         return var
-
-
 
     # def do_set_Navg(self, Navg):
     #     self.Navg = Navg

--- a/pycqed/instrument_drivers/physical_instruments/RTO1024.py
+++ b/pycqed/instrument_drivers/physical_instruments/RTO1024.py
@@ -5,11 +5,13 @@ from qcodes.instrument import visa
 from qcodes.utils import validators as vals
 from qcodes.instrument.parameter import ManualParameter
 
+
 class RTO1024_scope(visa.VisaInstrument):
     '''
     Instrument driver for the Rohde-Schwarz RTO1024 oscilloscope.
     Currently only able to measure signal on Channel 1.
     '''
+
     def __init__(self, name, address=None, timeout=5, terminator='',
                  **kwargs):
         super().__init__(name=name, address=address, timeout=timeout,
@@ -58,7 +60,7 @@ class RTO1024_scope(visa.VisaInstrument):
 
         # Load settings from file
         self.visa_handle.write("MMEM RCL " +
-            "'C:\\Users\\Instrument.RTO-XXXXXX\\Documents\\Data\\1703_Starmon\\Settings_2017-06-06.dfl'")
+                               "'C:\\Users\\Instrument.RTO-XXXXXX\\Documents\\Data\\1703_Starmon\\Settings_2017-06-06.dfl'")
         # Include x-values in output
         self.visa_handle.write('EXPort:WAVeform:INCXvalues ON')
 
@@ -69,7 +71,7 @@ class RTO1024_scope(visa.VisaInstrument):
         '''
         # defines the acquisition no. for run single mode
         self.visa_handle.write('EXPort:WAVeform:INCXvalues ON')
-        self.visa_handle.write('ACQuire:COUNt %s'%str(self.num_averages()))
+        self.visa_handle.write('ACQuire:COUNt %s' % str(self.num_averages()))
         self.visa_handle.write('RUNSingle')
         # Wait until measurement finishes before extracting data.
         # TODO: ask device if operation is complete

--- a/pycqed/instrument_drivers/physical_instruments/SCPIBase.py
+++ b/pycqed/instrument_drivers/physical_instruments/SCPIBase.py
@@ -106,7 +106,6 @@ class SCPIBase:
     def get_system_version(self) -> str:
         return self._ask('system:version?')
 
-
     def get_status_questionable_condition(self) -> int:
         return self._ask_int('STATus:QUEStionable:CONDition?')
 
@@ -118,7 +117,6 @@ class SCPIBase:
 
     def get_status_questionable_enable(self) -> int:
         return self._ask_int('STATus:QUEStionable:ENABle?')
-
 
     def get_status_operation_condition(self) -> int:
         return self._ask_int('STATus:OPERation:CONDition?')
@@ -170,41 +168,41 @@ class SCPIBase:
     ###
 
     # bits for *ESR and *ESE
-    ESR_OPERATION_COMPLETE      = 0x01
-    ESR_REQUEST_CONTROL         = 0x02
-    ESR_QUERY_ERROR             = 0x04
-    ESR_DEVICE_DEPENDENT_ERROR  = 0x08
-    ESR_EXECUTION_ERROR         = 0x10
-    ESR_COMMAND_ERROR           = 0x20
-    ESR_USER_REQUEST            = 0x40
-    ESR_POWER_ON                = 0x80
+    ESR_OPERATION_COMPLETE = 0x01
+    ESR_REQUEST_CONTROL = 0x02
+    ESR_QUERY_ERROR = 0x04
+    ESR_DEVICE_DEPENDENT_ERROR = 0x08
+    ESR_EXECUTION_ERROR = 0x10
+    ESR_COMMAND_ERROR = 0x20
+    ESR_USER_REQUEST = 0x40
+    ESR_POWER_ON = 0x80
 
     # bits for STATus:OPERation
     # FIXME: add the function
-    STAT_OPER_CALIBRATING       = 0x0001    # The instrument is currently performing a calibration
-    STAT_OPER_SETTLING          = 0x0002    # The instrument is waiting for signals it controls to stabilize enough to begin measurements
-    STAT_OPER_RANGING           = 0x0004    # The instrument is currently changing its range
-    STAT_OPER_SWEEPING          = 0x0008    # A sweep is in progress
-    STAT_OPER_MEASURING         = 0x0010    # The instrument is actively measuring
-    STAT_OPER_WAIT_TRIG         = 0x0020    # The instrument is in a “wait for trigger” state of the trigger model
-    STAT_OPER_WAIT_ARM          = 0x0040    # The instrument is in a “wait for arm” state of the trigger model
-    STAT_OPER_CORRECTING        = 0x0080    # The instrument is currently performing a correction
-    STAT_OPER_INST_SUMMARY      = 0x2000    # One of n multiple logical instruments is reporting OPERational status
-    STAT_OPER_PROG_RUNNING      = 0x4000    # A user-defined program is currently in the run state
+    STAT_OPER_CALIBRATING = 0x0001    # The instrument is currently performing a calibration
+    STAT_OPER_SETTLING = 0x0002    # The instrument is waiting for signals it controls to stabilize enough to begin measurements
+    STAT_OPER_RANGING = 0x0004    # The instrument is currently changing its range
+    STAT_OPER_SWEEPING = 0x0008    # A sweep is in progress
+    STAT_OPER_MEASURING = 0x0010    # The instrument is actively measuring
+    STAT_OPER_WAIT_TRIG = 0x0020    # The instrument is in a “wait for trigger” state of the trigger model
+    STAT_OPER_WAIT_ARM = 0x0040    # The instrument is in a “wait for arm” state of the trigger model
+    STAT_OPER_CORRECTING = 0x0080    # The instrument is currently performing a correction
+    STAT_OPER_INST_SUMMARY = 0x2000    # One of n multiple logical instruments is reporting OPERational status
+    STAT_OPER_PROG_RUNNING = 0x4000    # A user-defined program is currently in the run state
 
     # bits for STATus:QUEStionable
     # FIXME: add the function
-    STAT_QUES_VOLTAGE           = 0x0001
-    STAT_QUES_CURRENT           = 0x0002
-    STAT_QUES_TIME              = 0x0004
-    STAT_QUES_POWER             = 0x0008
-    STAT_QUES_TEMPERATURE       = 0x0010
-    STAT_QUES_FREQUENCY         = 0x0020
-    STAT_QUES_PHASE             = 0x0040
-    STAT_QUES_MODULATION        = 0x0080
-    STAT_QUES_CALIBRATION       = 0x0100
-    STAT_QUES_INST_SUMMARY      = 0x2000
-    STAT_QUES_COMMAND_WARNING   = 0x4000
+    STAT_QUES_VOLTAGE = 0x0001
+    STAT_QUES_CURRENT = 0x0002
+    STAT_QUES_TIME = 0x0004
+    STAT_QUES_POWER = 0x0008
+    STAT_QUES_TEMPERATURE = 0x0010
+    STAT_QUES_FREQUENCY = 0x0020
+    STAT_QUES_PHASE = 0x0040
+    STAT_QUES_MODULATION = 0x0080
+    STAT_QUES_CALIBRATION = 0x0100
+    STAT_QUES_INST_SUMMARY = 0x2000
+    STAT_QUES_COMMAND_WARNING = 0x4000
 
     ###
     # static methods
@@ -218,4 +216,3 @@ class SCPIBase:
         digit_cnt_str = str(len(byte_cnt_str))
         bin_header_str = '#' + digit_cnt_str + byte_cnt_str
         return bin_header_str
-

--- a/pycqed/instrument_drivers/physical_instruments/Stroboscope/Stroboscope.py
+++ b/pycqed/instrument_drivers/physical_instruments/Stroboscope/Stroboscope.py
@@ -39,31 +39,31 @@ class Stroboscope(VisaInstrument):
         super().__init__(name, address, **kwargs)
 
         # Add some global constants
-        self.MAX_DUTY = 698 ## milliseconds
-        self.MAX_PHASE = 698 ## milliseconds
+        self.MAX_DUTY = 698  # milliseconds
+        self.MAX_PHASE = 698  # milliseconds
         self._address = address
         self.visa_handle.baud_rate = 115200
         self.visa_handle.write_termination = '\r'
         self.visa_handle.read_termination = '\r'
 
         self.add_parameter('phase',
-            get_cmd='PHASE?',
-            get_parser=int,
-            set_cmd='PHASE {:d}',
-            vals=vals.Numbers(min_value=0,
-                              max_value=self.MAX_PHASE),
-            unit='ms')
+                           get_cmd='PHASE?',
+                           get_parser=int,
+                           set_cmd='PHASE {:d}',
+                           vals=vals.Numbers(min_value=0,
+                                             max_value=self.MAX_PHASE),
+                           unit='ms')
         self.add_parameter('duty_cycle',
-            get_cmd='DUTY?',
-            get_parser=int,
-            set_cmd='DUTY {:d}',
-            vals=vals.Numbers(min_value=0,
-                              max_value=self.MAX_DUTY),
-            unit='ms')
+                           get_cmd='DUTY?',
+                           get_parser=int,
+                           set_cmd='DUTY {:d}',
+                           vals=vals.Numbers(min_value=0,
+                                             max_value=self.MAX_DUTY),
+                           unit='ms')
         self.add_parameter('locked',
-            get_cmd='LOCK?',
-            get_parser=lambda s: bool(int(s)),
-            label='Trigger locked to pulse tube')
+                           get_cmd='LOCK?',
+                           get_parser=lambda s: bool(int(s)),
+                           label='Trigger locked to pulse tube')
 
         # time.sleep(3)
         # self.get_all()
@@ -87,7 +87,6 @@ class Stroboscope(VisaInstrument):
         self.duty_cycle()
         self.locked()
 
-
     def get_info(self):
         '''
         Get the device descriptor.
@@ -99,4 +98,3 @@ class Stroboscope(VisaInstrument):
         '''
         ans = self._visainstrument.ask('*IDN?')
         return ans
-

--- a/pycqed/instrument_drivers/physical_instruments/Transport.py
+++ b/pycqed/instrument_drivers/physical_instruments/Transport.py
@@ -36,7 +36,6 @@ class Transport:
         pass
 
 
-
 class IPTransport(Transport):
     """
     Based on: SCPI.py, QCoDeS::IPInstrument
@@ -44,14 +43,14 @@ class IPTransport(Transport):
 
     def __init__(self, host: str,
                  port: int = 5025,
-                 timeout = 30.0,
+                 timeout=30.0,
                  snd_buf_size: int = 512 * 1024) -> None:
         """
         establish connection, e.g. IPTransport('192.168.0.16', 4000)
         """
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.settimeout(timeout)  # first set timeout (before connect)
-        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, snd_buf_size) # beef up buffer
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, snd_buf_size)  # beef up buffer
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)  # send things immediately
         self._socket.connect((host, port))
 
@@ -107,12 +106,11 @@ class FileTransport(Transport):
         self._out_file.write(data)
 
     def read_binary(self, size: int) -> bytes:
-        pass # FIXME: implement
+        pass  # FIXME: implement
 
     def readline(self) -> str:
-        pass # FIXME: implement
-
+        pass  # FIXME: implement
 
 
 class DummyTransport(Transport):
-    pass # NB: only supports output (which goes nowhere) for now
+    pass  # NB: only supports output (which goes nowhere) for now

--- a/pycqed/instrument_drivers/physical_instruments/Weinschel_8320_novisa.py
+++ b/pycqed/instrument_drivers/physical_instruments/Weinschel_8320_novisa.py
@@ -39,4 +39,4 @@ class Weinschel_8320(Instrument):
         ret = tn.read_until(cmd_encoded, timeout=self.timeout)
         ret = ret.decode('ascii')
         tn.close()
-        return int(ret.split('\r\n')[-3],10)
+        return int(ret.split('\r\n')[-3], 10)

--- a/pycqed/instrument_drivers/physical_instruments/ZNB20.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZNB20.py
@@ -201,7 +201,7 @@ def VISA_str_to_int(message):
 def VISA_str_to_float(message):
     return float(message.strip('\\n'))
 
+
 # Ensuring backwards compatibility
 print('This is the version by Stefano, there is another version in QCoDeS')
 # from .ZNB import ZNB as ZNB20
-

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -60,7 +60,7 @@ import time
 import logging
 import inspect
 import numpy as np
-from typing import Tuple,List
+from typing import Tuple, List
 
 import pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_instrument as zibase
 import pycqed.instrument_drivers.library.DIO as DIO
@@ -90,10 +90,12 @@ class ziUHFQCHoldoffError(Exception):
     sent to these units to solve the problem."""
     pass
 
+
 class ziUHFQCDIOActivityError(Exception):
     """Exception raised when insufficient activity is detected on the bits
     of the DIO to be used for controlling which qubits to measure."""
     pass
+
 
 class ziUHFQCDIOCalibrationError(Exception):
     """Exception raised when the DIO calibration fails, meaning no signal
@@ -203,7 +205,7 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
                          **kw)
 
         # Disable disfunctional parameters from snapshot
-        self._params_to_exclude = set(['features_code', 'system_fwlog', 'system_fwlogenable']) # FIXME: duplicates prior statement
+        self._params_to_exclude = set(['features_code', 'system_fwlog', 'system_fwlogenable'])  # FIXME: duplicates prior statement
 
         # Set default waveform length to 20 ns at 1.8 GSa/s
         self._default_waveform_length = 32
@@ -599,7 +601,7 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
         return data
 
     def acquisition_get(self, samples, arm=True,
-                         acquisition_time=0.010):
+                        acquisition_time=0.010):
         """
         Waits for the UHFQC to finish a measurement then reads the data.
 
@@ -639,7 +641,7 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
         self.unsubs()
 
 # FIXME: merge conflict 20200918
-#<<<<<<< HEAD
+# <<<<<<< HEAD
 #        for p in self._acquisition_nodes:
 #            self.unsubs(p)
 #        self.unsubs(self._get_full_path('auxins/0/sample'))
@@ -662,10 +664,10 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
                                         rotation_angle=0,
                                         length=4096 / 1.8e9,
                                         scaling_factor=1) -> None:
-# FIXME: merge conflict 20200918
-#=======
-#    def check_errors(self, errors_to_ignore=None) -> None:
-#>>>>>>> ee1ccf208faf635329ea2c979da5757ce4ce8e14
+        # FIXME: merge conflict 20200918
+        # =======
+        #    def check_errors(self, errors_to_ignore=None) -> None:
+        # >>>>>>> ee1ccf208faf635329ea2c979da5757ce4ce8e14
         """
         Sets default integration weights for SSB modulation, beware does not
         load pulses or prepare the UFHQC progarm to do data acquisition
@@ -946,14 +948,14 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
             vals=validators.Lists())
 
         self.add_parameter('dio_calibration_delay',
-            set_cmd=self._set_dio_calibration_delay,
-            get_cmd=self._get_dio_calibration_delay,
-            unit='',
-            label='DIO Calibration delay',
-            docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
-            'to be applied on the DIO interface in order to achieve reliable sampling '
-            'of the codewords. The valid range is 0 to 15.',
-            vals=validators.Ints())
+                           set_cmd=self._set_dio_calibration_delay,
+                           get_cmd=self._get_dio_calibration_delay,
+                           unit='',
+                           label='DIO Calibration delay',
+                           docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
+                           'to be applied on the DIO interface in order to achieve reliable sampling '
+                           'of the codewords. The valid range is 0 to 15.',
+                           vals=validators.Ints())
 
     def _codeword_table_preamble(self, awg_nr) -> str:
         """
@@ -988,9 +990,9 @@ class UHFQC(zibase.ZI_base_instrument, DIO.CalInterface):
     # Overriding Qcodes InstrumentBase methods
     ##########################################################################
 
-    def snapshot_base(self, update: bool=False,
-                      params_to_skip_update =None,
-                      params_to_exclude = None ):
+    def snapshot_base(self, update: bool = False,
+                      params_to_skip_update=None,
+                      params_to_exclude=None):
         """
         State of the instrument as a JSON-compatible dict.
         Args:
@@ -1188,7 +1190,6 @@ setUserReg(4, err_cnt);"""
     ##########################################################################
     ##########################################################################
 
-
     ##########################################################################
     # 'public' functions: sequencer functions
     ##########################################################################
@@ -1299,21 +1300,21 @@ setUserReg(4, err_cnt);"""
         self.awgs_0_userregs_2(delay_samples)
         sequence = (
             'var wait_delay = getUserReg(2);\n' +
-            'cvar i = 0;\n'+
+            'cvar i = 0;\n' +
             'const length = {};\n'.format(len(dio_out_vect))
-            )
+        )
         sequence = sequence + _array2vect(dio_out_vect, "dio_out_vect")
         # starting the loop
-        sequence = sequence +(
-            'setDIO(2048); // FIXME: workaround because we cannot use setDIO(0)\n'+
+        sequence = sequence + (
+            'setDIO(2048); // FIXME: workaround because we cannot use setDIO(0)\n' +
             'for (i = 0; i < length; i = i + 1) {\n'
-            ' var dio_out =  dio_out_vect[i];\n'+
+            ' var dio_out =  dio_out_vect[i];\n' +
             ' waitDIOTrigger();\n' +
-            ' setDIO(dio_out);\n'+
+            ' setDIO(dio_out);\n' +
             ' wait(wait_delay);\n' +
-            ' setDIO(2048);\n'+
+            ' setDIO(2048);\n' +
             '}\n'
-            )
+        )
 
         # Define the behavior of our program
         self._reset_awg_program_features()
@@ -1438,7 +1439,7 @@ setTrigger(0);
 
     def awg_debug_acquisition(self, dly=0):
         self._reset_awg_program_features()
-        self._awg_program_features['avg_cnt']  = True
+        self._awg_program_features['avg_cnt'] = True
         self._awg_program_features['loop_cnt'] = True
         self._awg_program_features['wait_dly'] = True
 
@@ -1602,10 +1603,10 @@ setTrigger(0);
         """
         log.debug(f"{self.devname}: Testing DIO activity for AWG {awg_nr}")
 
-        vld_mask     = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
+        vld_mask = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
         vld_polarity = self.geti('awgs/{}/dio/valid/polarity'.format(awg_nr))
-        strb_mask    = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
-        strb_slope   = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
+        strb_mask = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
+        strb_slope = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
 
         cw_mask = mask_value  # FIXME: changed parameter to define mask that's already shifted in place << 17
 
@@ -1656,10 +1657,10 @@ setTrigger(0);
         codewords are sampled incorrectly."""
         log.debug("{self.devname}: Finding valid delays")
 
-        vld_mask     = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
+        vld_mask = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
         vld_polarity = self.geti('awgs/{}/dio/valid/polarity'.format(awg_nr))
-        strb_mask    = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
-        strb_slope   = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
+        strb_mask = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
+        strb_slope = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
 
         cw_mask = mask_value << 17
 
@@ -1670,7 +1671,7 @@ setTrigger(0);
             combined_mask |= strb_mask
         log.debug(f"{self.devname}:   Using a mask value of 0x{combined_mask:08x}")
 
-        valid_delays= []
+        valid_delays = []
         for delay in range(12):  # NB: 16 steps are available, but 2 periods of 20 ns should suffice
             log.debug(f'{self.devname}:    Testing delay {delay}')
             self.setd('raw/dios/0/delay', delay)  # in 1/300 MHz = 3.33 ns steps
@@ -1690,7 +1691,7 @@ setTrigger(0);
     # overrides for CalInterface interface
     ##########################################################################
 
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
         # NB: ignoring dio_mode and port, because we have single mode only
         program = """
         // program: triggered upstream DIO calibration program
@@ -1711,9 +1712,9 @@ setTrigger(0);
 
         dio_mask = 0x000003FF
         expected_sequence = []
-        return dio_mask,expected_sequence
+        return dio_mask, expected_sequence
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0):
         log.info(f"{self.devname}: Calibrating DIO protocol")
         self.assure_ext_clock()
 
@@ -1725,46 +1726,46 @@ setTrigger(0);
         awg_enable = self.get('awgs_0_enable')
 
         try:
-          self.set('qas_0_integration_length', 4)
-          self.set('qas_0_result_enable', 0)
-          self.set('qas_0_monitor_enable', 0)
-          self.set('awgs_0_enable', 0)
-          
-          for awg in [0]:
-              if not self._ensure_activity(awg, mask_value=dio_mask):
-                  raise ziUHFQCDIOActivityError('No or insufficient activity found on the DIO bits associated with AWG {}'.format(awg))
+            self.set('qas_0_integration_length', 4)
+            self.set('qas_0_result_enable', 0)
+            self.set('qas_0_monitor_enable', 0)
+            self.set('awgs_0_enable', 0)
 
-          valid_delays = self._find_valid_delays(awg, mask_value=dio_mask)
-          if len(valid_delays) == 0:
-              raise ziUHFQCDIOCalibrationError('DIO calibration failed! No valid delays found')
+            for awg in [0]:
+                if not self._ensure_activity(awg, mask_value=dio_mask):
+                    raise ziUHFQCDIOActivityError('No or insufficient activity found on the DIO bits associated with AWG {}'.format(awg))
 
-          # Find center of first valid region
-          subseq = [[]]
-          for e in valid_delays:
-              if not subseq[-1] or subseq[-1][-1] == e - 1:
-                  subseq[-1].append(e)
-              else:
-                  subseq.append([e])
+            valid_delays = self._find_valid_delays(awg, mask_value=dio_mask)
+            if len(valid_delays) == 0:
+                raise ziUHFQCDIOCalibrationError('DIO calibration failed! No valid delays found')
 
-          subseq = max(subseq, key=len)
-          delay = len(subseq)//2 + subseq[0]
+            # Find center of first valid region
+            subseq = [[]]
+            for e in valid_delays:
+                if not subseq[-1] or subseq[-1][-1] == e - 1:
+                    subseq[-1].append(e)
+                else:
+                    subseq.append([e])
 
-          # Print information
-          log.info(f"{self.devname}: Valid delays are {valid_delays}")
+            subseq = max(subseq, key=len)
+            delay = len(subseq)//2 + subseq[0]
 
-          # And configure the delays
-          self._set_dio_calibration_delay(delay)
+            # Print information
+            log.info(f"{self.devname}: Valid delays are {valid_delays}")
 
-          # Clear all detected errors (caused by DIO timing calibration)
-          self.check_errors(errors_to_ignore=['AWGDIOTIMING'])
-        
+            # And configure the delays
+            self._set_dio_calibration_delay(delay)
+
+            # Clear all detected errors (caused by DIO timing calibration)
+            self.check_errors(errors_to_ignore=['AWGDIOTIMING'])
+
         finally:
-          # Restore settings either in case of an exception or if the DIO
-          # routine finishes correctly
-          self.set('qas_0_integration_length', integration_length)
-          self.set('qas_0_result_enable', result_enable)
-          self.set('qas_0_monitor_enable', monitor_enable)
-          self.set('awgs_0_enable', awg_enable)
+            # Restore settings either in case of an exception or if the DIO
+            # routine finishes correctly
+            self.set('qas_0_integration_length', integration_length)
+            self.set('qas_0_result_enable', result_enable)
+            self.set('qas_0_monitor_enable', monitor_enable)
+            self.set('awgs_0_enable', awg_enable)
 
     ##########################################################################
     # DIO calibration functions for *CC*
@@ -1809,6 +1810,7 @@ if (ro_mode) {
   ro_trig = AWG_INTEGRATION_ARM + AWG_INTEGRATION_TRIGGER;
 }"""
     return preamble
+
 
 def _array2vect(array, name):
     # this function cuts up arrays into several vectors of maximum length 1024 that are joined.

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
@@ -86,7 +86,7 @@ import time
 import logging
 import numpy as np
 import re
-from typing import Tuple,List
+from typing import Tuple, List
 
 import pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_instrument as zibase
 import pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_HDAWG_core as zicore
@@ -102,9 +102,11 @@ log = logging.getLogger(__name__)
 # Exceptions
 ##########################################################################
 
+
 class ziDIOActivityError(Exception):
     """Exception raised when no activity is found on the DIO bus during calibration."""
     pass
+
 
 class ziDIOCalibrationError(Exception):
     """Exception raised when DIO calibration fails."""
@@ -114,6 +116,7 @@ class ziDIOCalibrationError(Exception):
 # Class
 ##########################################################################
 
+
 class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
 
     def __init__(self,
@@ -121,7 +124,7 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
                  device: str,
                  interface: str = '1GbE',
                  server: str = 'localhost',
-                 port = 8004,
+                 port=8004,
                  num_codewords: int = 32,
                  **kw) -> None:
         """
@@ -143,7 +146,7 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
 
         # show some info
         log.info('{}: DIO interface found in mode {}'
-                 .format(self.devname, 'CMOS' if self.get('dios_0_interface') == 0 else 'LVDS')) # NB: mode is persistent across device restarts
+                 .format(self.devname, 'CMOS' if self.get('dios_0_interface') == 0 else 'LVDS'))  # NB: mode is persistent across device restarts
 
         # Ensure snapshot is fairly small for HDAWGs
         self._snapshot_whitelist = {
@@ -221,29 +224,29 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
             parameter_class=ManualParameter)
 
         self.add_parameter('dio_calibration_delay',
-                    set_cmd=self._set_dio_calibration_delay,
-                    get_cmd=self._get_dio_calibration_delay,
-                    unit='',
-                    label='DIO Calibration delay',
-                    docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
-                    'to be applied on the DIO interface in order to achieve reliable sampling'
-                    ' of the codewords. The valid range is 0 to 15.',
-                    vals=validators.Ints())
+                           set_cmd=self._set_dio_calibration_delay,
+                           get_cmd=self._get_dio_calibration_delay,
+                           unit='',
+                           label='DIO Calibration delay',
+                           docstring='Configures the internal delay in 300 MHz cycles (3.3 ns) '
+                           'to be applied on the DIO interface in order to achieve reliable sampling'
+                           ' of the codewords. The valid range is 0 to 15.',
+                           vals=validators.Ints())
 
         for i in range(4):
             for ch in range(2):
                 self.add_parameter(f'awgs_{i}_outputs_{ch}_amplitude',
-                            set_cmd=self._gen_set_awgs_outputs_amplitude(i, ch),
-                            get_cmd=self._gen_get_awgs_outputs_amplitude(i, ch),
-                            unit='FS',
-                            label=f'AWG {i} output {ch} amplitude (legacy, deprecated)',
-                            docstring=f'Configures the amplitude in full scale units of AWG {i} output {ch} (zero-indexed). Note: this parameter is deprecated, use awgs_{ch}_outputs_{ch}_gains_{ch} instead',
-                            vals=validators.Numbers())
+                                   set_cmd=self._gen_set_awgs_outputs_amplitude(i, ch),
+                                   get_cmd=self._gen_get_awgs_outputs_amplitude(i, ch),
+                                   unit='FS',
+                                   label=f'AWG {i} output {ch} amplitude (legacy, deprecated)',
+                                   docstring=f'Configures the amplitude in full scale units of AWG {i} output {ch} (zero-indexed). Note: this parameter is deprecated, use awgs_{ch}_outputs_{ch}_gains_{ch} instead',
+                                   vals=validators.Numbers())
 
     # FIXME: why the override, does not seem necessary now QCoDeS PRs 1161/1163 have been merged
-    def snapshot_base(self, update: bool=False,
-                      params_to_skip_update =None,
-                      params_to_exclude = None ):
+    def snapshot_base(self, update: bool = False,
+                      params_to_skip_update=None,
+                      params_to_exclude=None):
         """
         State of the instrument as a JSON-compatible dict.
         Args:
@@ -256,7 +259,6 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
         Returns:
             dict: base snapshot
         """
-
 
         if params_to_exclude is None:
             params_to_exclude = self._params_to_exclude
@@ -411,10 +413,10 @@ while (1) {
             if 0:  # FIXME: remove after testing PR #621
                 num_codewords = int(2 ** np.ceil(np.log2(self._num_codewords)))
                 dio_mode_list = {
-                    'identical':            { 'mask': 0xFF, 'shift': [0,  0,  0,  0] },
-                    'microwave':            { 'mask': 0xFF, 'shift': [0,  0,  16, 16] },    # bits [7:0] and [23:16]
-                    'novsm_microwave':      { 'mask': 0x7F, 'shift': [0,  7,  16, 23] },    # bits [6:0], [13:7], [22:16] and [29:23]
-                    'flux':                 { 'mask': 0x3F, 'shift': [0,  6,  16, 22] },    # FIXME: mask for 2 channels
+                    'identical':            {'mask': 0xFF, 'shift': [0,  0,  0,  0]},
+                    'microwave':            {'mask': 0xFF, 'shift': [0,  0,  16, 16]},    # bits [7:0] and [23:16]
+                    'novsm_microwave':      {'mask': 0x7F, 'shift': [0,  7,  16, 23]},    # bits [6:0], [13:7], [22:16] and [29:23]
+                    'flux':                 {'mask': 0x3F, 'shift': [0,  6,  16, 22]},    # FIXME: mask for 2 channels
                 }
                 # FIXME: define DIO modes centrally in device independent way (lsb, width, channelCount)
                 dio_mode = dio_mode_list.get(self.cfg_codeword_protocol())
@@ -427,7 +429,7 @@ while (1) {
                 # FIXME: flux mode sets mask, using 6 bits=2channels
             else:
                 channels = [2*awg_nr, 2*awg_nr+1]
-                shift,mask = DIO.get_shift_and_mask(self.cfg_codeword_protocol(), channels)
+                shift, mask = DIO.get_shift_and_mask(self.cfg_codeword_protocol(), channels)
                 self.set(f'awgs_{awg_nr}_dio_mask_value', mask)
                 self.set(f'awgs_{awg_nr}_dio_mask_shift', shift)
 
@@ -566,15 +568,15 @@ while (1) {
         """
         log.debug(f"Testing DIO activity for AWG {awg_nr}")
 
-        vld_mask     = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
+        vld_mask = 1 << self.geti('awgs/{}/dio/valid/index'.format(awg_nr))
         vld_polarity = self.geti('awgs/{}/dio/valid/polarity'.format(awg_nr))
-        strb_mask    = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
-        strb_slope   = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
+        strb_mask = (1 << self.geti('awgs/{}/dio/strobe/index'.format(awg_nr)))
+        strb_slope = self.geti('awgs/{}/dio/strobe/slope'.format(awg_nr))
 
         if mask_value is None:
             mask_value = self.geti('awgs/{}/dio/mask/value'.format(awg_nr))
 
-        cw_mask      = mask_value #<< self.geti('awgs/{}/dio/mask/shift'.format(awg_nr))
+        cw_mask = mask_value  # << self.geti('awgs/{}/dio/mask/shift'.format(awg_nr))
 
         for i in range(timeout):
             valid = True
@@ -613,7 +615,7 @@ while (1) {
         configured bits. In addition, it compares the recorded DIO codewords to an expected sequence to make sure that no
         codewords are sampled incorrectly."""
         log.debug("  Finding valid delays")
-        valid_delays= []
+        valid_delays = []
         for delay in range(16):
             log.debug(f'   Testing delay {delay}')
             self.setd('raw/dios/0/delays/*/value', delay)
@@ -637,7 +639,8 @@ while (1) {
                             last_index = index
                             index = (index + 1) % len(sequence)
                             if cw != sequence[index]:
-                                log.warning("Codeword {} with value {} not expected to follow codeword {} in expected sequence {}!".format(n, cw, sequence[last_index], sequence))
+                                log.warning("Codeword {} with value {} not expected to follow codeword {} in expected sequence {}!".format(
+                                    n, cw, sequence[last_index], sequence))
                                 log.info(f"Detected codeword sequence: {cws}")
                                 valid_sequence = False
                                 break
@@ -806,7 +809,7 @@ while (1) {
     # NB: based on UHFQuantumController.py::_prepare_HDAWG8_dio_calibration
     # FIXME: also requires fiddling with DIO data direction
     # FIXME: is this guaranteed to be synchronous to 10 MHz?
-    def output_dio_calibration_data(self, dio_mode: str, port: int=0) -> Tuple[int, List]:
+    def output_dio_calibration_data(self, dio_mode: str, port: int = 0) -> Tuple[int, List]:
         """
         Configures an HDAWG with a default program that generates data suitable for DIO calibration.
         Also starts the HDAWG.
@@ -827,9 +830,9 @@ while (1) {
 
         dio_mask = 0x7fff0000
         expected_sequence = []
-        return dio_mask,expected_sequence
+        return dio_mask, expected_sequence
 
-    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
+    def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int = 0):
         # FIXME: UHF driver does not use expected_sequence, why the difference
         self.assure_ext_clock()
         self.upload_codeword_program()

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
@@ -49,6 +49,7 @@ import pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_
 
 log = logging.getLogger(__name__)
 
+
 class ZI_HDAWG_core(zibase.ZI_base_instrument):
     """
     This is PycQED/QCoDeS driver driver for the Zurich Instruments HDAWG.
@@ -123,13 +124,16 @@ class ZI_HDAWG_core(zibase.ZI_base_instrument):
         Checks that sufficient versions of the firmware are available.
         """
         if self.geti('system/fwrevision') < ZI_HDAWG_core.MIN_FWREVISION:
-            raise zibase.ziVersionError('Insufficient firmware revision detected! Need {}, got {}!'.format(ZI_HDAWG_core.MIN_FWREVISION, self.geti('system/fwrevision')))
+            raise zibase.ziVersionError('Insufficient firmware revision detected! Need {}, got {}!'.format(
+                ZI_HDAWG_core.MIN_FWREVISION, self.geti('system/fwrevision')))
 
         if self.geti('system/fpgarevision') < ZI_HDAWG_core.MIN_FPGAREVISION:
-            raise zibase.ziVersionError('Insufficient FPGA revision detected! Need {}, got {}!'.format(ZI_HDAWG_core.MIN_FPGAREVISION, self.geti('system/fpgarevision')))
+            raise zibase.ziVersionError('Insufficient FPGA revision detected! Need {}, got {}!'.format(
+                ZI_HDAWG_core.MIN_FPGAREVISION, self.geti('system/fpgarevision')))
 
         if self.geti('system/slaverevision') < ZI_HDAWG_core.MIN_SLAVEREVISION:
-            raise zibase.ziVersionError('Insufficient FPGA Slave revision detected! Need {}, got {}!'.format(ZI_HDAWG_core.MIN_SLAVEREVISION, self.geti('system/slaverevision')))
+            raise zibase.ziVersionError('Insufficient FPGA Slave revision detected! Need {}, got {}!'.format(
+                ZI_HDAWG_core.MIN_SLAVEREVISION, self.geti('system/slaverevision')))
 
     def _num_channels(self):
         if self.devtype == 'HDAWG8':
@@ -224,16 +228,16 @@ class ZI_HDAWG_core(zibase.ZI_base_instrument):
 
         # Go through the errors and update our structure, raise exceptions if anything changed
         for m in errors['messages']:
-            code     = m['code']
-            count    = m['count']
+            code = m['code']
+            count = m['count']
             severity = m['severity']
-            message  = m['message']
+            message = m['message']
 
             if not raise_exceptions:
                 self._errors[code] = {
-                    'count'   : count,
+                    'count': count,
                     'severity': severity,
-                    'message' : message}
+                    'message': message}
                 log.warning(f'{self.devname}: Code {code}: "{message}" ({severity})')
             else:
                 # Check if there are new errors
@@ -248,9 +252,9 @@ class ZI_HDAWG_core(zibase.ZI_base_instrument):
                     self._errors[code]['count'] = count
                 else:
                     self._errors[code] = {
-                        'count'   : count,
+                        'count': count,
                         'severity': severity,
-                        'message' : message}
+                        'message': message}
 
         if found_errors:
             log.error('Errors detected during run-time!')

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -318,7 +318,7 @@ class MockDAQServer():
                 'type': 'String', 'value': '{"sequence_nr" : 0, "new_errors" : 0, "first_timestamp" : 0, "timestamp" : 0, "timestamp_utc" : "2019-08-07 17 : 33 : 55", "messages" : []}'}
             for i in range(32):
                 self.nodes['/' + self.device +
-                        '/raw/dios/0/delays/' + str(i) + '/value'] = {'type': 'Integer', 'value': 0}
+                           '/raw/dios/0/delays/' + str(i) + '/value'] = {'type': 'Integer', 'value': 0}
             self.nodes[f'/{self.device}/raw/error/blinkseverity'] = {'type': 'Integer', 'value': 0}
             self.nodes[f'/{self.device}/raw/error/blinkforever'] = {'type': 'Integer', 'value': 0}
             self.nodes[f'/{self.device}/dios/0/extclk'] = {'type': 'Integer', 'value': 0}
@@ -611,12 +611,12 @@ class ZI_base_instrument(Instrument):
     def __init__(self,
                  name: str,
                  device: str,
-                 interface: str= '1GbE',
-                 server: str= 'localhost',
-                 port: int= 8004,
-                 apilevel: int= 5,
-                 num_codewords: int= 0,
-                 logfile:str = None,
+                 interface: str = '1GbE',
+                 server: str = 'localhost',
+                 port: int = 8004,
+                 apilevel: int = 5,
+                 num_codewords: int = 0,
+                 logfile: str = None,
                  **kw) -> None:
         """
         Input arguments:
@@ -1299,13 +1299,13 @@ class ZI_base_instrument(Instrument):
 
         return None
 
-    def subs(self, path:str) -> None:
+    def subs(self, path: str) -> None:
         full_path = self._get_full_path(path)
         if full_path not in self._subscribed_paths:
             self._subscribed_paths.append(full_path)
         self.daq.subscribe(full_path)
 
-    def unsubs(self, path:str=None) -> None:
+    def unsubs(self, path: str = None) -> None:
         if path is None:
             for path in self._subscribed_paths:
                 self.daq.unsubscribe(path)
@@ -1397,7 +1397,6 @@ class ZI_base_instrument(Instrument):
         """
         self._errors_to_ignore.append(code)
 
-
     def reset_waveforms_zeros(self):
         """
         Sets all waveforms to an array of 48 zeros.
@@ -1414,7 +1413,7 @@ class ZI_base_instrument(Instrument):
         log.info('Set all waveforms to zeros in {:.1f} ms'.format(1.0e3*(t1-t0)))
 
     def configure_awg_from_string(self, awg_nr: int, program_string: str,
-                                  timeout: float=15):
+                                  timeout: float = 15):
         """
         Uploads a program string to one of the AWGs in a UHF-QA or AWG-8.
 

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_tools.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_tools.py
@@ -6,6 +6,8 @@ import matplotlib.pyplot as plt
 
 # from: AWG8_staircase_test.ipynb
 # FIXME: superceded by ZI_base_instrument
+
+
 def plot_timing_diagram(data, bits, line_length=30):
     def _plot_lines(ax, pos, *args, **kwargs):
         if ax == 'x':

--- a/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
+++ b/pycqed/instrument_drivers/physical_instruments/_CCL/CCLightMicrocode.py
@@ -147,12 +147,12 @@ class CCLightMicrocode():
             self.disa_cs_line(cs_line)
 
         print("{:3d} {:6s} ".format(cw_left, "(" +
-                self.type_dict[op_type_left] + ")"),
-                end = '')
+                                    self.type_dict[op_type_left] + ")"),
+              end='')
         if op_type_right != 0:
             print("{:3d} {:6s}  ".format(cw_right, "(" +
-                self.type_dict[op_type_right] + ")"),
-                end = '')
+                                         self.type_dict[op_type_right] + ")"),
+                  end='')
         if condition != 0:
             print("condition: {}".format(condition), end='')
 
@@ -194,7 +194,7 @@ class CCLightMicrocode():
             if cs_line > (1 << 22) - 1:
                 raise ValueError("The maximum value of a cs_line is: 2**22 -1."
                                  "{} is given at position {}.".format(
-                                    cs_line, idx))
+                                     cs_line, idx))
 
     def load_microcode(self, filename):
         try:
@@ -261,7 +261,6 @@ class CCLightMicrocode():
         print("Condition  OpTypeLeft  CW_Left  OptypeRight  CW_Right")
         for i in range(len(cs_line_array)):
             self.print_pure_cs_line(cs_line_array[i])
-
 
     def insert_cs_line(self, line_number, condition, op_type_left,
                        cw_left, op_type_right=0, cw_right=0):

--- a/pycqed/instrument_drivers/physical_instruments/_QCC/QCCMicrocode.py
+++ b/pycqed/instrument_drivers/physical_instruments/_QCC/QCCMicrocode.py
@@ -145,12 +145,12 @@ class QCCMicrocode():
             self.disa_cs_line(cs_line)
 
         print("{:3d} {:6s} ".format(cw_left, "(" +
-                self.type_dict[op_type_left] + ")"),
-                end = '')
+                                    self.type_dict[op_type_left] + ")"),
+              end='')
         if op_type_right != 0:
             print("{:3d} {:6s}  ".format(cw_right, "(" +
-                self.type_dict[op_type_right] + ")"),
-                end = '')
+                                         self.type_dict[op_type_right] + ")"),
+                  end='')
         if condition != 0:
             print("condition: {}".format(condition), end='')
 
@@ -192,7 +192,7 @@ class QCCMicrocode():
             if cs_line > (1 << 22) - 1:
                 raise ValueError("The maximum value of a cs_line is: 2**22 -1."
                                  "{} is given at position {}.".format(
-                                    cs_line, idx))
+                                     cs_line, idx))
 
     def load_microcode(self, filename):
         try:
@@ -260,7 +260,6 @@ class QCCMicrocode():
         print("Condition  OpTypeLeft  CW_Left  OptypeRight  CW_Right")
         for i in range(len(cs_line_array)):
             self.print_pure_cs_line(cs_line_array[i])
-
 
     def insert_cs_line(self, line_number, condition, op_type_left,
                        cw_left, op_type_right=0, cw_right=0):

--- a/pycqed/instrument_drivers/physical_instruments/american_magnetics/AMI430.py
+++ b/pycqed/instrument_drivers/physical_instruments/american_magnetics/AMI430.py
@@ -112,7 +112,7 @@ class AMI430(IPInstrument):
             self.add_parameter('in_persistent_mode',
                                get_cmd='PERS?',
                                val_mapping={False: 0, True: 1})
-            #FIXME: this throws an error in hdf5.data's write_dict_to_hdf5
+            # FIXME: this throws an error in hdf5.data's write_dict_to_hdf5
             # Exception occurred while writing False:0 of type <class 'int'>
             # "WARNING:root:'bool' object has no attribute 'encode'"
             # Exception occurred while writing True:1 of type <class 'int'>
@@ -124,12 +124,12 @@ class AMI430(IPInstrument):
             # This function is only called from the measurement_control
             # (Technically also from base_analysis, but this does not cause a problem)
 
-            #FIXME: there is a bug here.
-            #The get command returns a string from the AMI interface
-            #The set command needs a boolean to pass to _set_persistent_switch
+            # FIXME: there is a bug here.
+            # The get command returns a string from the AMI interface
+            # The set command needs a boolean to pass to _set_persistent_switch
 
-            #Proposed fixes, need to be tested in a safe environment
-            #Because I'm not sure i this solves it
+            # Proposed fixes, need to be tested in a safe environment
+            # Because I'm not sure i this solves it
             # self.add_parameter('switch_heater_enabled',
             #                    get_cmd='PS?',
             #                    set_cmd=self._set_persistent_switch,
@@ -146,24 +146,19 @@ class AMI430(IPInstrument):
 
             # self.add_parameter('in_persistent_mode',
             #                    get_cmd='PERS?',
-                                # get_parser=int,
+            # get_parser=int,
             #                    val_mapping={False: 0, True: 1})
 
-
-
-        #And this one causes it as well
+        # And this one causes it as well
         self.add_parameter('is_quenched',
                            get_cmd='QU?',
                            val_mapping={False: 0, True: 1})
-        #Proposed fixes, this is the easiest one to test on, since we cannot
+        # Proposed fixes, this is the easiest one to test on, since we cannot
         # screw it up
         # self.add_parameter('is_quenched',
         #            get_cmd='QU?',
         #            get_parser = int
         #            val_mapping={False: 0, True: 1})
-
-
-
 
         self.add_function('reset_quench', call_cmd='QU 0')
         self.add_function('set_quenched', call_cmd='QU 1')
@@ -257,7 +252,6 @@ class AMI430(IPInstrument):
         if self._can_start_ramping():
             # self.pause()
 
-
             # If we have a persistent switch, make sure it is resistive
             if self._persistent_switch:
                 if not self.switch_heater_enabled():
@@ -301,7 +295,6 @@ class AMI430(IPInstrument):
 
         if self._can_start_ramping():
             self.pause()
-
 
             # If we have a persistent switch, make sure it is resistive
             if self._persistent_switch:


### PR DESCRIPTION
Changes proposed in this pull request:
- Apply autopep to python files in the repo

Using automatic formatters keeps code clean and allows for a uniform coding style. This PR applied autopep8 (basic settings, but with max line length 120). This is in line with the issue template and contributing guidelines which prefer autopep8 (https://github.com/DiCarloLab-Delft/PycQED_py3/blob/develop/.github/CONTRIBUTING.md)

Related is #649 which adds configuration files to automatically format according to autopep8 on commiting.

Once we agree, we will autopep all files in the repository.

@wvlothuizen @MiguelSMoreira 