### PR TITLE
Added functionality to use asynchronous versions of the setter functions to speed up device configuration

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import logging
 import re
 from datetime import datetime
+from functools import partial
 
 from qcodes.instrument.base import Instrument
 from qcodes.utils import validators
@@ -256,6 +257,7 @@ class MockDAQServer():
         self.devtype = None
         self.poll_nodes = []
         self.verbose = verbose
+        self.async_nodes = []
 
     def awgModule(self):
         return MockAwgModule(self)
@@ -385,6 +387,16 @@ class MockDAQServer():
 
         self.nodes[path]['value'] = value
 
+    def asyncSetInt(self, path, value):
+        if path not in self.nodes:
+            raise ziRuntimeError("Unknown node '" + path +
+                                 "' used with mocked server and device!")
+
+        if self.verbose:
+            print('asyncSetInt', path, value)
+
+        self.async_nodes.append(partial(self.setInt, path, value))
+
     def setDouble(self, path, value):
         if path not in self.nodes:
             raise ziRuntimeError("Unknown node '" + path +
@@ -392,6 +404,15 @@ class MockDAQServer():
         if self.verbose:
             print('setDouble', path, value)
         self.nodes[path]['value'] = value
+
+    def asyncSetDouble(self, path, value):
+        if path not in self.nodes:
+            raise ziRuntimeError("Unknown node '" + path +
+                                 "' used with mocked server and device!")
+        if self.verbose:
+            print('setDouble', path, value)
+
+        self.async_nodes.append(partial(self.setDouble, path, value))
 
     def setVector(self, path, value):
         if path not in self.nodes:
@@ -481,10 +502,11 @@ class MockDAQServer():
             self.poll_nodes.remove(path)
 
     def sync(self):
-        """The sync method does not need to do anything as there are no
-        device delays to deal with when using the mock server.
+        """The sync method does not need to do anything except goes through
+        the list of nodes set asynchronously and executes those.
         """
-        pass
+        for p in self.async_nodes:
+            p()
 
     def _load_parameter_file(self, filename: str):
         """
@@ -564,7 +586,7 @@ class MockAwgModule():
         if path == 'awgModule/device':
             value = [self._device]
         elif path == 'awgModule/index':
-            value[self._index]
+            value = [self._index]
         elif path == 'awgModule/compiler/statusstring':
             value = ['File successfully uploaded']
         else:
@@ -707,6 +729,9 @@ class ZI_base_instrument(Instrument):
         self._errors_to_ignore = []
         # Make initial error check
         self.check_errors()
+
+        # Default is not to use async mode
+        self._async_mode = False
 
         # Optionally setup log file
         if logfile is not None:
@@ -1242,21 +1267,30 @@ class ZI_base_instrument(Instrument):
 
     def setd(self, path, value) -> None:
         self._write_cmd_to_logfile(f'daq.setDouble("{path}", {value})')
-        self.daq.setDouble(self._get_full_path(path), value)
+        if self._async_mode:
+            self.daq.asyncSetDouble(self._get_full_path(path), value)
+        else:
+            self.daq.setDouble(self._get_full_path(path), value)
 
     def getd(self, path):
         return self.daq.getDouble(self._get_full_path(path))
 
     def seti(self, path, value) -> None:
         self._write_cmd_to_logfile(f'daq.setDouble("{path}", {value})')
-        self.daq.setInt(self._get_full_path(path), value)
+        if self._async_mode:
+            self.daq.asyncSetInt(self._get_full_path(path), value)
+        else:
+            self.daq.setInt(self._get_full_path(path), value)
 
     def geti(self, path):
         return self.daq.getInt(self._get_full_path(path))
 
     def sets(self, path, value) -> None:
         self._write_cmd_to_logfile(f'daq.setString("{path}", {value})')
-        self.daq.setString(self._get_full_path(path), value)
+        if self._async_mode:
+            self.daq.asyncSetString(self._get_full_path(path), value)
+        else:
+            self.daq.setString(self._get_full_path(path), value)
 
     def gets(self, path):
         return self.daq.getString(self._get_full_path(path))
@@ -1509,3 +1543,10 @@ class ZI_base_instrument(Instrument):
 
     def assure_ext_clock(self) -> None:
         raise NotImplementedError('Virtual method with no implementation!')
+
+    def asyncBegin(self):
+        self._async_mode = True
+
+    def asyncEnd(self):
+        self.daq.sync()
+        self._async_mode = False 

--- a/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
+++ b/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQC.py
@@ -166,3 +166,15 @@ class Test_UHFQC(unittest.TestCase):
         Test_UHFQC.uhf.close()
         self.setup_class()
         self.assertEqual(Test_UHFQC.uhf.devname, 'dev2109')
+
+    def test_async(self):
+        self.uhf.awgs_0_userregs_0(0)
+        self.uhf.awgs_0_triggers_0_level(0.0)
+        self.uhf.asyncBegin()
+        self.uhf.awgs_0_userregs_0(100)
+        self.uhf.awgs_0_triggers_0_level(1.123)
+        assert self.uhf.awgs_0_userregs_0() == 0
+        assert self.uhf.awgs_0_triggers_0_level() == 0
+        self.uhf.asyncEnd()
+        assert self.uhf.awgs_0_userregs_0() == 100
+        assert self.uhf.awgs_0_triggers_0_level() == 1.123


### PR DESCRIPTION
The purpose of this PR is to add support for setting device settings faster by not waiting for a response from the server. The functionality is implemented using `asyncBegin` and `asyncEnd` added to the base class of the ZI drivers. Use the functionality like this:

```
uhf = UHFQC(...)
uhf.asyncBegin()
uhf.sigouts_0_on(1)
uhf.sigouts_1_on(1)
uhf.sigouts_0_imp50(True)
uhf.sigouts_1_imp50(True)
uhf.asyncEnd()
```
The driver will wait for all the writes to complete after `asyncEnd()` is called.

Fixes #192.

Changes proposed in this pull request:
- Added `asyncBegin` and `asyncEnd` methods to `ZI_base_instrument`
- Updated such that `asyncSetInt` and `asyncSetDouble` are used after `asyncBegin` 
- Updated such that `asyncEnd` calls the `daq.sync()` function causing the driver to wait for all writes to complete.
- Added unit test of new functionality.
- Updated `MockDAQServer` to support asynchronous versions of the `set` methods.

@mention the name of someone you want to review this pull request. 

In order for the pull request to be merged, the following conditions must be met:
- test suite (Github actions) passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


