### PR TITLE
Making UHFQA_core work

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -800,7 +800,7 @@ class ZI_base_instrument(Instrument):
         raise NotImplementedError('Virtual method with no implementation!')
 
     def _get_waveform_table(self, awg_nr: int) -> list:
-        raise NotImplementedError('Virtual method with no implementation!')    
+        return dict()    
 
     def _add_extra_parameters(self) -> None:
         """

--- a/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQA_core.py
+++ b/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQA_core.py
@@ -140,3 +140,6 @@ class Test_UHFQA_core(unittest.TestCase):
         assert self.uhf.qas_0_rotations_3() == (1-1j)
         self.uhf.reset_rotation_params()
         assert self.uhf.qas_0_rotations_3() == (1+1j)
+
+    def test_start(self):
+        self.uhf.start()


### PR DESCRIPTION
Fixed bug in `_get_waveform_table` preventing start() from working in UHFQA_core. After refactoring there was some functionality preventing `UHFQA_core` and derived classes from executing experiments.

Changes proposed in this pull request:
- Changed default implementation of `_get_waveform_table` to return an empty `dict()`
- Added unittest of `start()` for `UHFQA_core

@chellings 

In order for the pull request to be merged, the following conditions must be met:
- test suite (Github actions) passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


