### PR TITLE
Raise zishell's logging level to status

### DIFF
--- a/deprecated/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/attic/zishell.py
+++ b/deprecated/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/attic/zishell.py
@@ -1,6 +1,6 @@
 # N.B. !!!!!!!
-# This file should match the zishell_nh.py but was provided by Yves for 
-# debugging in may 2019. Note that this file is not used in the rest of PycQED. 
+# This file should match the zishell_nh.py but was provided by Yves for
+# debugging in may 2019. Note that this file is not used in the rest of PycQED.
 
 
 #!/usr/bin/ipython
@@ -406,7 +406,7 @@ class ziShellDevice:
         if not self.daq:
             raise(ziShellDAQError())
 
-        self.daq.setDebugLevel(0)
+        self.daq.setDebugLevel(3)
         self.connected = False
 
         if self.device and self.interface:


### PR DESCRIPTION
Avoid log message spam from `ziDAQServer` by raising the log level to
3 (status).

Completes #663.

@MiguelSMoreira 
