### PR TITLE
Move minimum_holdoff from UHFQC to UHFQA_core (including unit test)

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQA_core.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQA_core.py
@@ -200,6 +200,14 @@ class UHFQA_core(zibase.ZI_base_instrument):
             'actual readout.',
             vals=validators.Ints())
 
+        self.add_parameter(
+            'minimum_holdoff',
+            get_cmd=self._get_minimum_holdoff,
+            unit='s',
+            label='Minimum hold-off',
+            docstring='Returns the minimum allowed hold-off between two readout operations.',
+            vals=validators.Numbers())
+
     ##########################################################################
     # 'public' overrides for ZI_base_instrument
     ##########################################################################
@@ -655,6 +663,14 @@ class UHFQA_core(zibase.ZI_base_instrument):
             'waves': False,
             'cases': False,
             'diocws': False}
+
+    def _get_minimum_holdoff(self):
+        if self.qas_0_result_averages() == 1:
+            holdoff = np.max((800, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
+        else:
+            holdoff = np.max((2560, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
+
+        return holdoff
 
     def _set_wait_dly(self, value) -> None:
         self.set('awgs_0_userregs_{}'.format(UHFQA_core.USER_REG_WAIT_DLY), value)

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQuantumController.py
@@ -320,14 +320,6 @@ class UHFQC(uhf.UHFQA_core, DIO.CalInterface):
             'of the codewords. The valid range is 0 to 15.',
             vals=validators.Ints())
 
-        self.add_parameter(
-            'minimum_holdoff',
-            get_cmd=self._get_minimum_holdoff,
-            unit='s',
-            label='Minimum hold-off',
-            docstring='Returns the minimum allowed hold-off between two readout operations.',
-            vals=validators.Numbers())
-
     def _codeword_table_preamble(self, awg_nr) -> str:
         """
         Defines a snippet of code to use in the beginning of an AWG program in order to define the waveforms.
@@ -446,14 +438,6 @@ class UHFQC(uhf.UHFQA_core, DIO.CalInterface):
 
     def _get_dio_calibration_delay(self):
         return self._dio_calibration_delay
-
-    def _get_minimum_holdoff(self):
-        if self.qas_0_result_averages() == 1:
-            holdoff = np.max((800, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
-        else:
-            holdoff = np.max((2560, self.qas_0_integration_length(), self.qas_0_delay()+16))/self.clock_freq()
-
-        return holdoff
 
     def _set_wait_dly(self, value) -> None:
         self.set('awgs_0_userregs_{}'.format(UHFQC.USER_REG_WAIT_DLY), value)

--- a/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQA_core.py
+++ b/pycqed/tests/instrument_drivers/physical_instruments/test_UHFQA_core.py
@@ -87,6 +87,27 @@ class Test_UHFQA_core(unittest.TestCase):
         f.seek(0)
         self.assertIn('User registers overview', f.read())
 
+    def test_minimum_holdoff(self):
+        # Test without averaging
+        self.uhf.qas_0_integration_length(128)
+        self.uhf.qas_0_result_averages(1)
+        self.uhf.qas_0_delay(0)
+        assert self.uhf.minimum_holdoff() == 800/1.8e9
+        self.uhf.qas_0_delay(896)
+        assert self.uhf.minimum_holdoff() == (896+16)/1.8e9
+        self.uhf.qas_0_integration_length(2048)
+        assert self.uhf.minimum_holdoff() == (2048)/1.8e9
+
+        # Test with averaging
+        self.uhf.qas_0_result_averages(16)
+        self.uhf.qas_0_delay(0)
+        self.uhf.qas_0_integration_length(128)
+        assert self.uhf.minimum_holdoff() == 2560/1.8e9
+        self.uhf.qas_0_delay(896)
+        assert self.uhf.minimum_holdoff() == 2560/1.8e9
+        self.uhf.qas_0_integration_length(4096)
+        assert self.uhf.minimum_holdoff() == 4096/1.8e9
+
     def test_crosstalk_matrix(self):
         mat = np.random.random((10, 10))
         self.uhf.upload_crosstalk_matrix(mat)


### PR DESCRIPTION
This feature from #651 belongs into the UHFQA_core driver (lower-layer driver shared by TUD and ETH) that was introduced in #656. The feature ended up in the wrong place because the two pull requests were processed in parallel. This pull request moves the minimum_holdoff calculation to the correct class, and also adds the corresponding unit test originally written as part of #651  to the test module of the core driver.

@MiguelSMoreira 