### PR TITLE
Martinr/shfqa driver

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -916,7 +916,7 @@ class ZI_base_instrument(Instrument):
                 par_kw['set_cmd'] = _gen_set_cmd(self.setv, parpath)
                 par_kw['get_cmd'] = _gen_get_cmd(self.getv, parpath)
                 # min/max not implemented yet for ZI auto docstrings #352
-                par_kw['vals'] = validators.Arrays()
+                par_kw['vals'] = validators.Arrays(valid_types=(complex, np.integer, np.floating))
 
             elif par['Type'] == 'String':
                 par_kw['set_cmd'] = _gen_set_cmd(self.sets, parpath)

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -898,8 +898,7 @@ class ZI_base_instrument(Instrument):
             elif par['Type'] == 'Integer (enumerated)':
                 par_kw['set_cmd'] = _gen_set_cmd(self.seti, parpath)
                 par_kw['get_cmd'] = _gen_get_cmd(self.geti, parpath)
-                par_kw['vals'] = validators.Ints(min_value=0,
-                                                 max_value=len(par["Options"]))
+                par_kw['vals'] = validators.Ints()
 
             elif par['Type'] == 'Double':
                 par_kw['set_cmd'] = _gen_set_cmd(self.setd, parpath)

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -724,8 +724,8 @@ class ZI_base_instrument(Instrument):
             self._awg_waveforms = {}
 
             # Asserted when AWG needs to be reconfigured
-            self._awg_needs_configuration = [False]*(self._num_channels()//2)
-            self._awg_program = [None]*(self._num_channels()//2)
+            self._awg_needs_configuration = [False]*(self._num_awgs())
+            self._awg_program = [None]*(self._num_awgs())
 
             # Create waveform parameters
             self._num_codewords = 0
@@ -800,6 +800,9 @@ class ZI_base_instrument(Instrument):
 
     def _num_channels(self):
         raise NotImplementedError('Virtual method with no implementation!')
+
+    def _num_awgs(self):
+        return self._num_channels()//2
 
     def _get_waveform_table(self, awg_nr: int) -> list:
         return dict()
@@ -1382,7 +1385,7 @@ class ZI_base_instrument(Instrument):
         self.check_errors()
 
         # Loop through each AWG and check whether to reconfigure it
-        for awg_nr in range(self._num_channels()//2):
+        for awg_nr in range(self._num_awgs()):
             self._length_match_waveforms(awg_nr)
 
             # If the reconfiguration flag is set, upload new program
@@ -1398,7 +1401,7 @@ class ZI_base_instrument(Instrument):
                 self._clear_dirty_waveforms(awg_nr)
 
         # Start all AWG's
-        for awg_nr in range(self._num_channels()//2):
+        for awg_nr in range(self._num_awgs()):
             # Skip AWG's without programs
             if self._awg_program[awg_nr] is None:
                 # to configure all awgs use "upload_codeword_program" or specify
@@ -1416,7 +1419,7 @@ class ZI_base_instrument(Instrument):
     def stop(self):
         log.info(f"{self.devname}: Stopping '{self.name}'")
         # Stop all AWG's
-        for awg_nr in range(self._num_channels()//2):
+        for awg_nr in range(self._num_awgs()):
             self.set('awgs_{}_enable'.format(awg_nr), 0)
 
         self.check_errors()

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/internal/_shfqa.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/internal/_shfqa.py
@@ -1,0 +1,932 @@
+"""Module collecting implementation details of the SHFQA driver."""
+
+import textwrap
+import numpy as np
+import logging
+
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+
+import zhinst.deviceutils.shfqa as shfqa_utils
+from zhinst.utils import wait_for_state_change
+
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_instrument import (
+    ziConfigurationError,
+    ziValueError,
+)
+
+log = logging.getLogger(__name__)
+
+
+class DeviceConstants:
+    """
+    Class collecting device constants under one common namespace.
+    """
+
+    class MinRevisions:
+        """
+        Minimum revision numbers required to operate the driver.
+        """
+
+        FW = 63210
+        FPGA = 63133
+
+    class GeneratorWaveforms:
+        """
+        Constants related to generator waveforms.
+        """
+
+        MAX_LENGTH = 4096
+        GRANULARITY = 4
+
+    class Averaging:
+        """
+        Constants relating hardware averaging algorithms to their corresponding integer encodings.
+        """
+
+        SEQUENTIAL = 1
+        CYCLIC = 0
+
+    class Readout:
+        """
+        Constants related to the readout mode ("rl" in driver lingo) of the SHFQA.
+        """
+
+        MAX_LENGTH = 4096
+        GRANULARITY = 4
+        QACHANNEL_MODE = 1
+        RESULT_OF_INTEGRATION = 1
+        RESULT_OF_DISCRIMINATION = 3
+
+    class Scope:
+        """
+        Constants related to the scope monitor mode ("ro" in driver lingo) of the SHFQA.
+        """
+
+        MAX_LENGTH = 2 ** 18
+        GRANULARITY = 32
+
+    class Spectroscopy:
+        """
+        Constants related to the spectroscopy mode of the SHFQA.
+        """
+
+        MAX_LENGTH = 2 ** 25
+        GRANULARITY = 4
+        QACHANNEL_MODE = 0
+        TRIGGER_SOURCE = 32  # hardwired to channel0_sequencer_trigger0
+
+    class Sequencer:
+        NUM_REGISTERS = 16
+
+    SAMPLING_FREQUENCY = shfqa_utils.SHFQA_SAMPLING_FREQUENCY
+
+    class Holdoff:
+        """
+        Constants related to measurement hold-off.
+        """
+
+        MARGIN = 72e-9
+        PLAYZERO_GRANULARITY = 16
+        MIN_LENGTH = 2048
+
+
+def preprocess_generator_waveform(waveform) -> None:
+    """
+    Validates a candidate complex array candidate for upload onto a generator slot of the device. The
+    function additionally snaps the length of the array to the granularity of the generator.
+
+    Args:
+        waveform: complex array representing a candidate waveform to be uploaded to a device generator slot.
+    """
+    granularity = DeviceConstants.GeneratorWaveforms.GRANULARITY
+    original_size = len(waveform)
+    if (original_size % granularity) != 0:
+        log.debug(
+            f"Waveform is not a multiple of {granularity} samples, appending zeroes."
+        )
+        extra_zeroes = granularity - (original_size % granularity)
+        waveform = np.concatenate([waveform, np.zeros(extra_zeroes)])
+
+    if original_size > DeviceConstants.GeneratorWaveforms.MAX_LENGTH:
+        raise ziValueError(
+            f"Exceeding maximum generator wave length of {DeviceConstants.GeneratorWaveforms.MAX_LENGTH} samples "
+            f"(trying to upload {len(waveform)} samples)"
+        )
+    return waveform
+
+
+def hold_off_length(readout_duration: float) -> int:
+    """
+    Returns the number of samples to wait for between subsequent readouts to ensure no hold-off errors occur.
+
+    Args:
+        readout_duration: total duration of the readout operation.
+    """
+    readout_length = duration_to_length(
+        readout_duration + DeviceConstants.Holdoff.MARGIN
+    )
+    granularity = DeviceConstants.Holdoff.PLAYZERO_GRANULARITY
+    snapped_length = (
+        ((readout_length + (granularity - 1))) // granularity
+    ) * granularity
+    if snapped_length < DeviceConstants.Holdoff.MIN_LENGTH:
+        log.debug(
+            f"The configured time between readout pulse generation and the end of the integration of {readout_duration} "
+            f"seconds is shorter than the minimum holdoff length of {DeviceConstants.Holdoff.MIN_LENGTH} samples with a"
+            f" sampling rate of {DeviceConstants.SAMPLING_FREQUENCY}."
+        )
+        return DeviceConstants.Holdoff.MIN_LENGTH
+    return snapped_length
+
+
+class UserRegisters:
+    """
+    Class assigning functionality to specific user registers.
+    """
+
+    INNER_LOOP = 0
+    OUTER_LOOP = 1
+    HOLDOFF_DELAY = 2
+    NUM_ERRORS = 3
+
+
+class SeqC:
+    """
+    Class collecting functionality relating to SHFQA sequencer programs under one common namespace.
+    """
+
+    _VAR_INNER_LOOP_SIZE = "inner_loop_size"
+    _VAR_OUTER_LOOP_SIZE = "outer_loop_size"
+    _VAR_INNER_LOOP_INDEX = "inner_loop_index"
+    _VAR_OUTER_LOOP_INDEX = "outer_loop_index"
+    _VAR_HOLDOFF_DELAY = "holdoff_delay"
+    _VAR_NUM_ERRORS = "num_errors"
+    _VAR_CODEWORD = "codeword"
+    _VAR_CODEWORD_MASK = "codeword_mask"
+
+    _SPECTROSCOPY_OSCILLATOR_INDEX = 0
+
+    @dataclass(frozen=True)
+    class Features:
+        """
+        Dataclass specifying the main features of a sequencer program. Used to ensure that uploaded sequencer
+        programs are consistent with other device configurations at any given time.
+        """
+
+        inner_loop: bool
+        outer_loop: bool
+        spectroscopy: bool
+        codewords: bool
+
+    @dataclass(frozen=True)
+    class LoopSizes:
+        """
+        Dataclass specifying the loop counts of the sequencer program. Used to ensure that uploaded sequencer
+        programs are consistent with other device configurations at any given time.
+        """
+
+        inner: int
+        outer: int
+
+    @staticmethod
+    def acquisition_and_DIO_triggered_pulse(
+        mask: int, shift: int, cases: dict
+    ) -> tuple:
+        """
+        Returns a tuple containing a SeqC.Features instance and a program string specifying an experiment where:
+
+        The acquisition is started after receiving a DIO trigger, with different generator and integrator slots being
+        triggered based on the value of the codeword stored within the DIO trigger value. The "num_errors" user register
+        is incremented each time a codeword is received that is not included in the list specified by the "cases"
+        argument. The total number of readouts is specified by the variable stored in the "num_samples" user register.
+
+        Args:
+            cases: dictionary whose entries {codeword: slot_indices} specify which generator and integrator slots to
+                   trigger for each codeword.
+        """
+        features = SeqC.Features(
+            inner_loop=True, outer_loop=False, spectroscopy=False, codewords=True
+        )
+
+        program = SeqC._preamble(features)
+        program += SeqC._var_definition(SeqC._VAR_NUM_ERRORS, 0)
+        program += SeqC._set_register(UserRegisters.NUM_ERRORS, 0)
+
+        switch = []
+        for case, indices in cases.items():
+            startQA = SeqC._readout(
+                generator_mask=SeqC._make_mask("QA_GEN_", indices),
+                integrator_mask=SeqC._make_mask("QA_INT_", indices),
+            )
+            case = SeqC._scope(preamble=f"case {bin(case)}:", body=startQA)
+            switch.append(case)
+        dummy_readout = SeqC._readout(
+            generator_mask=0,
+            integrator_mask="QA_INT_7",  # This is a temporary hack - this value must be different than 0 to trigger the result logger
+        )
+        default = SeqC._scope(
+            preamble="default:", body=dummy_readout + f"{SeqC._VAR_NUM_ERRORS} += 1;\n"
+        )
+        switch.append(default)
+        switch = SeqC._scope(preamble=f"switch({SeqC._VAR_CODEWORD})", body=switch)
+
+        repeat = SeqC._play_zero(SeqC._VAR_HOLDOFF_DELAY)
+        repeat += SeqC._wait_dio_trigger()
+        repeat += SeqC._var_definition(
+            SeqC._VAR_CODEWORD, SeqC._dio_codeword(mask, shift)
+        )
+        repeat += switch
+        repeat = SeqC._scope(
+            preamble=f"repeat ({SeqC._VAR_INNER_LOOP_SIZE})", body=repeat
+        )
+
+        program += repeat
+        program += SeqC._set_register(UserRegisters.NUM_ERRORS, SeqC._VAR_NUM_ERRORS)
+
+        return features, program
+
+    @staticmethod
+    def acquisition_and_pulse(
+        slot: int,
+        dio_trigger: bool = False,
+    ) -> tuple:
+        """
+        Returns a tuple containing a SeqC.Features instance and a program string specifying an experiment where:
+
+        The acquisition is started after optionally receiving a digital trigger, with the readout pulse
+        and integration weights stored in the first generator and integrator slot, respectively.
+        The total number of readouts is specified by the variable stored in the "num_samples" user
+        register.
+
+        Args:
+            dio_trigger: specify whether or not the readout gets triggered by DIO.
+        """
+        features = SeqC.Features(
+            inner_loop=True, outer_loop=False, spectroscopy=False, codewords=False
+        )
+
+        program = SeqC._preamble(features)
+
+        repeat = SeqC._play_zero(SeqC._VAR_HOLDOFF_DELAY)
+        if dio_trigger:
+            repeat += SeqC._wait_dio_trigger()
+        repeat += SeqC._readout(
+            generator_mask=SeqC._make_mask("QA_GEN_", [slot]),
+            integrator_mask=SeqC._make_mask("QA_INT_", [slot]),
+        )
+        repeat = SeqC._scope(
+            preamble=f"repeat ({SeqC._VAR_INNER_LOOP_SIZE})",
+            body=repeat,
+        )
+
+        program += repeat
+
+        return features, program
+
+    @staticmethod
+    def acquisition(slot: int) -> tuple:
+        """
+        Returns a tuple containing a SeqC.Features instance and a program string specifying an experiment where:
+
+        The acquisition is started after receiving a digital trigger, without playing any readout pulse and
+        using the integration weights stored in the first integrator slot. The total number of readouts
+        is specified by the variable stored in the "num_samples" user register.
+        """
+        features = SeqC.Features(
+            inner_loop=True, outer_loop=False, spectroscopy=False, codewords=False
+        )
+
+        program = SeqC._preamble(features)
+
+        repeat = SeqC._play_zero(SeqC._VAR_HOLDOFF_DELAY)
+        repeat += SeqC._wait_dio_trigger()
+        repeat += SeqC._readout(
+            generator_mask="0",
+            integrator_mask=SeqC._make_mask("QA_INT_", [slot]),
+        )
+        repeat = SeqC._scope(
+            preamble=f"repeat ({SeqC._VAR_INNER_LOOP_SIZE})", body=repeat
+        )
+
+        program += repeat
+
+        return features, program
+
+    @staticmethod
+    def spectroscopy(
+        start_frequency: float, frequency_step: float, dio_trigger: bool
+    ) -> tuple:
+        """
+        Returns a tuple containing a SeqC.Features instance and a program string specifying a sequencer-based
+        spectroscopy experiment:
+
+        The acquisition is started after receiving an optional DIO trigger. The number of frequency steps and averages
+        is specified by the variables stored in the "num_samples" and "num_averages" user register, respectively.
+
+        Args:
+            start_frequency: starting point of the frequency sweep
+            frequency_step: offset added to the previous frequency value at each new step
+            dio_trigger: specify whether the different frequency steps are self-triggered, or via a DIO trigger.
+        """
+        features = SeqC.Features(
+            inner_loop=True, outer_loop=True, spectroscopy=True, codewords=False
+        )
+
+        program = SeqC._preamble(features)
+        program += SeqC._unset_trigger()
+        program += SeqC._configure_frequency_sweep(start_frequency, frequency_step)
+
+        repeat = SeqC._play_zero(SeqC._VAR_HOLDOFF_DELAY)
+        if dio_trigger:
+            repeat += SeqC._wait_dio_trigger()
+        repeat += SeqC._set_sweep_step(SeqC._VAR_INNER_LOOP_INDEX)
+        repeat += SeqC._set_trigger()
+        repeat += SeqC._unset_trigger()
+
+        loop_preamble = f"for(var {SeqC._VAR_INNER_LOOP_INDEX} = 0; {SeqC._VAR_INNER_LOOP_INDEX} < {SeqC._VAR_INNER_LOOP_SIZE}; {SeqC._VAR_INNER_LOOP_INDEX}++)"
+        repeat = SeqC._scope(
+            preamble=loop_preamble,
+            body=repeat,
+        )
+        repeat = SeqC._scope(
+            preamble=f"for(var {SeqC._VAR_OUTER_LOOP_INDEX} = 0; {SeqC._VAR_OUTER_LOOP_INDEX} < {SeqC._VAR_OUTER_LOOP_SIZE}; {SeqC._VAR_OUTER_LOOP_INDEX}++)",
+            body=repeat,
+        )
+
+        program += repeat
+
+        return features, program
+
+    @staticmethod
+    def _preamble(features) -> str:
+        """
+        Returns an SHFQA sequencer program preamble defining and initializing variables from values stored in user
+        registers based on the features passed in as arguments.
+
+        Args:
+            features: dataclass instance specifying which variables to define and initialize.
+        """
+        preamble = ""
+        if features.inner_loop:
+            preamble += SeqC._var_definition(
+                SeqC._VAR_INNER_LOOP_SIZE, SeqC._get_register(UserRegisters.INNER_LOOP)
+            )
+        if features.outer_loop:
+            preamble += SeqC._var_definition(
+                SeqC._VAR_OUTER_LOOP_SIZE, SeqC._get_register(UserRegisters.OUTER_LOOP)
+            )
+        preamble += SeqC._var_definition(
+            SeqC._VAR_HOLDOFF_DELAY, SeqC._get_register(UserRegisters.HOLDOFF_DELAY)
+        )
+        return preamble
+
+    @staticmethod
+    def _dio_codeword(mask: int, shift: int) -> str:
+        """
+        Returns a SeqC string that corresponds to the value of the codeword currently present at the DIO interface.
+        """
+        return f"(getDIOTriggered() & {bin(mask)}) >> {shift}"
+
+    @staticmethod
+    def _var_definition(name: str, value) -> str:
+        """
+        Returns a SeqC command string that defines a run-time variable.
+
+        Args:
+            name: name of the variable to define.
+            value: initial value to assign to the variable.
+        """
+        return f"var {name} = {value};\n"
+
+    @staticmethod
+    def _set_register(index: int, value) -> str:
+        """
+        Returns a SeqC command string that sets the value of a user register.
+
+        Args:
+            index: index of the user register.
+            value: value to assign to the above user register.
+        """
+        return f"setUserReg({index}, {value});\n"
+
+    @staticmethod
+    def _get_register(index: int) -> str:
+        """
+        Returns a SeqC string that corresponds to the value of a specific user register. Note: this string does not
+        represent a command.
+
+        Args:
+            index: index of the user register from which to query the value
+        """
+        return f"getUserReg({index})"
+
+    @staticmethod
+    def _scope(preamble, body) -> str:
+        """
+        Returns a SeqC command string that encloses another program string inside a scope (brackets) with a preamble
+        inside of parentheses. Can be used to build e.g. loops and switch statements.
+
+        Args:
+            preamble: string enclosed in parentheses before the start of the scope.
+            body: string enclosed within brackets.
+        """
+        try:
+            string = ""
+            for line in body:
+                string += line
+            body = string
+        except TypeError:
+            pass
+        body = textwrap.indent(body, "\t")
+
+        return preamble + "\n" + f"{{\n{body}}}\n"
+
+    @staticmethod
+    def _readout(generator_mask: str, integrator_mask: str) -> str:
+        """
+        Returns a SeqC command string specifying a readout operation on the SHFQA. Note: this command also triggers the
+        sequencer monitor used to trigger the scope.
+
+        Args:
+            generator_mask: specifies which generators to trigger
+            integrator_mask: specifies which integration units to trigger
+        """
+        return f"startQA({generator_mask}, {integrator_mask}, true,  0, 0x0);\n"
+
+    @staticmethod
+    def _play_zero(num_samples: int) -> str:
+        """
+        Returns a SeqC command string specifying a blocking wait.
+
+        Args:
+            num_samples: number of samples to block until the next execution of '_play_zero'.
+        """
+        return f"playZero({num_samples});\n"
+
+    @staticmethod
+    def _configure_frequency_sweep(
+        start_frequency: float, frequency_step: float
+    ) -> str:
+        """
+        Returns a SeqC command string configuring a sequencer-based frequency sweep. Must be used in conjunction with
+        '_set_sweep_step'.
+
+        Args:
+            start_frequency: starting point of the frequency sweep
+            frequency_step: offset added to the previous frequency value at each new step
+        """
+        return f"configFreqSweep({SeqC._SPECTROSCOPY_OSCILLATOR_INDEX}, {start_frequency}, {frequency_step});\n"
+
+    @staticmethod
+    def _set_sweep_step(step_index: int) -> str:
+        """
+        Returns a SeqC command string specifying the setting of the IF frequency of the oscillator. For this command
+        to have any effect, '_configure_frequency_sweep' must have been called previously.
+
+        Args:
+            step_index: index specifying the value of the frequency to set to the IF oscillator. The actual value is
+                        determined at runtime and presupposes '_configure_frequency_sweep' has been called in the
+                        current program.
+        """
+        command = (
+            f"setSweepStep({SeqC._SPECTROSCOPY_OSCILLATOR_INDEX}, {step_index});\n"
+        )
+        command += "resetOscPhase();\n"
+
+        return command
+
+    @staticmethod
+    def _wait_dio_trigger() -> str:
+        """
+        Returns a SeqC command string specifying a blocking wait for a DIO trigger.
+        """
+        return "waitDIOTrigger();\n"
+
+    @staticmethod
+    def _set_trigger() -> str:
+        """
+        Returns a SeqC command string setting the sequencer trigger.
+        """
+        return "setTrigger(1);\n"
+
+    @staticmethod
+    def _unset_trigger() -> str:
+        """
+        Returns a SeqC command string unsetting the sequencer trigger.
+        """
+        return "setTrigger(0);\n"
+
+    @staticmethod
+    def _make_mask(specifier: str, indices: list) -> str:
+        """
+        Returns a string specifying a mask variable based on indices that can be used as arguments for a readout
+        command.
+
+        Args:
+            specifier: e.g. "QA_GEN_" for generators, and "QA_INT_" for integration units.
+            indices: list of indices constituting the desired mask.
+        """
+        if not indices:
+            return "0"
+        mask = ""
+        for i in indices[:-1]:
+            mask += specifier + f"{i}|"
+        mask += specifier + f"{indices[-1]}"
+
+        return mask
+
+
+def make_result_mode_manager(driver, result_mode: str):
+    """
+    Returns a concrete ResultModeManager object capable of managing the provided driver instance as specified by the
+    provided result mode.
+
+    Args:
+        driver: SHFQA driver instance to be managed.
+        result_mode: result mode on which to dispatch.
+
+    Raises:
+        ziValueError: the provided result mode is not supported.
+    """
+    if result_mode == "rl":
+        return _ReadoutModeManager(driver)
+    if result_mode == "ro":
+        return _ScopeModeManager(driver)
+    if result_mode == "spectroscopy":
+        return _SpectroscopyModeManager(driver)
+
+    _raise_unsupported_result_mode(result_mode)
+
+
+class ResultModeManager(ABC):
+    """
+    Abstract base encapsulating the handling of different measurement modes of the SHFQA device.
+    """
+
+    def __init__(self, driver):
+        self._driver = driver
+
+    def result_paths(self) -> set:
+        """
+        Returns all the nodes paths expected to contain measurement data. Accumulates data returned by the abstract
+        '_result_path' method over the currently active measurement units of the device.
+        """
+        node_paths = set()
+        for ch, integrators in self._driver.active_slots.items():
+            for integrator in integrators:
+                node_paths.add(self._result_path(ch, integrator))
+        return node_paths
+
+    @abstractmethod
+    def validate_config(self) -> None:
+        """
+        Validates the driver configuration with the configured result mode. Can be used to e.g. enforce that sequencer
+        programs currently cached in the driver are consistent with the result mode before actually pushing the whole
+        configuration to the device.
+
+        Raises:
+            ziConfigurationError: the driver configuration is incompatible with the current result mode.
+        """
+        pass
+
+    @abstractmethod
+    def extract_data(self, samples: int, data: dict = None) -> dict:
+        """
+        Extracts measurement data corresponding to the configured result mode from the device.
+
+        Args:
+            samples: number of expected measurement samples
+            data: optional raw data source to extract the data from
+        """
+        pass
+
+    @abstractmethod
+    def push_acquisition_unit_config(self) -> None:
+        """
+        Sets the measurement configuration to the device acquisition units corresponding to the current result mode.
+        """
+        pass
+
+    @abstractmethod
+    def start_acquisition_units(self) -> None:
+        """
+        Starts the device acquisition units corresponding to the current result mode.
+        """
+        pass
+
+    @abstractmethod
+    def wait_acquisition_units_finished(self) -> None:
+        """
+        Starts the device acquisition units corresponding to the current result mode.
+        """
+        pass
+
+    def _acquisition_time_to_length(self) -> int:
+        """
+        Top level function applying device constraints to the acquisition time set by the user through the driver.
+        """
+        length = duration_to_length(self._driver._acquisition_time)
+        new_length = (
+            length // self._acquisition_granularity()
+        ) * self._acquisition_granularity()
+        new_length = min(new_length, self._max_acquisition_length())
+        self._driver._acquisition_time = length_to_duration(new_length)
+        if length != new_length:
+            log.info(
+                f"{self._driver.devname}: changed the acquisition time from {length_to_duration(length)} to "
+                f"{self._driver._acquisition_time}."
+            )
+        return new_length
+
+    @abstractmethod
+    def _acquisition_granularity(self) -> int:
+        """
+        Returns the granularity for the given result mode. The value is used to clamp down the final number of samples
+        to acquire.
+        """
+        pass
+
+    @abstractmethod
+    def _max_acquisition_length(self) -> int:
+        """
+        Returns the maximal number of samples that can be recorded for the given result mode.
+        """
+        pass
+
+    @abstractmethod
+    def _result_path(self, ch: int, integrator: int = None) -> str:
+        """
+        Returns a result path corresponding to the current result mode and the provided channel and integrator index.
+
+        Args:
+            ch: channel index
+            integrator: optional integrator index.
+        """
+        pass
+
+
+class _ReadoutModeManager(ResultModeManager):
+    # Override
+    def validate_config(self) -> None:
+        if self._driver._seqc_features.spectroscopy:
+            raise ziConfigurationError(
+                "The configured sequencer program is only valid in the 'spectroscopy' result mode."
+            )
+
+    # Override
+    def extract_data(self, samples: int, data: dict = None) -> dict:
+        result = {}
+        for ch, integrators in self._driver.active_slots.items():
+            for integrator in integrators:
+                path = self._result_path(ch, integrator)
+                node_tree = data if data else self._driver.daq.get(path, flat=True)
+                vector = _get_vector_from_node_tree(node_tree, path)
+                if vector is not None:
+                    new_entry = {integrator: vector}
+                    try:
+                        result[ch].update(new_entry)
+                    except KeyError:
+                        result[ch] = new_entry
+        return result
+
+    # Override
+    def push_acquisition_unit_config(self) -> None:
+        for ch in self._driver.active_channels:
+            shfqa_utils.configure_result_logger_for_readout(
+                self._driver.daq,
+                self._driver.devname,
+                channel_index=ch,
+                result_source=self._driver._result_source,
+                result_length=self._driver._samples,
+                num_averages=self._driver._averages,
+                averaging_mode=_averaging_mode_to_int(self._driver._averaging_mode),
+            )
+            self._driver.set(
+                f"qachannels_{ch}_mode",
+                DeviceConstants.Readout.QACHANNEL_MODE,
+            )
+            self._driver.set(
+                f"qachannels_{ch}_readout_integration_delay",
+                self._driver._wait_dly,
+            )
+            self._driver.set(
+                f"qachannels_{ch}_readout_integration_length",
+                self._acquisition_time_to_length(),
+            )
+
+    # Override
+    def start_acquisition_units(self) -> None:
+        for ch in self._driver.active_channels:
+            shfqa_utils.enable_result_logger(
+                self._driver.daq,
+                self._driver.devname,
+                channel_index=ch,
+                mode="readout",
+            )
+
+    # Override
+    def wait_acquisition_units_finished(self) -> None:
+        for ch in self._driver.active_channels:
+            path = f"/{self._driver.devname}/qachannels/{ch}/readout/result/enable"
+            wait_for_state_change(
+                self._driver.daq, path, 0, timeout=self._driver.timeout()
+            )
+
+    # Override
+    def _acquisition_granularity(self) -> int:
+        return DeviceConstants.Readout.GRANULARITY
+
+    # Override
+    def _max_acquisition_length(self) -> int:
+        return DeviceConstants.Readout.MAX_LENGTH
+
+    # Override
+    def _result_path(self, ch: int, integrator: int = None) -> str:
+        return f"/{self._driver.devname}/qachannels/{ch}/readout/result/data/{integrator}/wave"
+
+
+class _ScopeModeManager(ResultModeManager):
+    # Override
+    def validate_config(self) -> None:
+        if self._driver._seqc_features.spectroscopy:
+            raise ziConfigurationError(
+                "The configured sequencer program is only valid in the 'spectroscopy' result mode."
+            )
+        if self._driver._averaging_mode == "cyclic" and self._driver._averages > 1:
+            raise ziConfigurationError(
+                "Cyclic averaging is not supported in 'ro' mode."
+            )
+
+    # Override
+    def extract_data(self, samples: int, data: dict = None) -> dict:
+        result = {}
+        for ch in self._driver.active_channels:
+            path = self._result_path(ch)
+            node_tree = data if data else self._driver.daq.get(path, flat=True)
+            vector = _get_vector_from_node_tree(node_tree, path)
+            if vector is not None:
+                result[ch] = np.array_split(vector, samples)
+        return result
+
+    # Override
+    def push_acquisition_unit_config(self) -> None:
+        scope_trigger_input, scope_input_select = self._scope_configuration()
+        shfqa_utils.configure_scope(
+            self._driver.daq,
+            self._driver.devname,
+            input_select=scope_input_select,
+            num_samples=self._acquisition_time_to_length(),
+            trigger_input=scope_trigger_input,
+            num_segments=self._driver._samples,
+            num_averages=self._driver._averages,
+            trigger_delay=self._driver._wait_dly,
+        )
+
+    # Override
+    def start_acquisition_units(self) -> None:
+        shfqa_utils.enable_scope(self._driver.daq, self._driver.devname, single=1)
+
+    # Override
+    def wait_acquisition_units_finished(self) -> None:
+        path = f"/{self._driver.devname}/scopes/0/enable"
+        wait_for_state_change(self._driver.daq, path, 0, timeout=self._driver.timeout())
+
+    # Override
+    def _acquisition_granularity(self) -> int:
+        return DeviceConstants.Scope.GRANULARITY
+
+    # Override
+    def _max_acquisition_length(self) -> int:
+        return (
+            DeviceConstants.Scope.MAX_LENGTH // len(self._driver.active_channels)
+        ) // self._driver._samples
+
+    # Override
+    def _result_path(self, ch: int, integrator: int = None) -> str:
+        return f"/{self._driver.devname}/scopes/0/channels/{ch}/wave"
+
+    def _scope_configuration(self) -> tuple:
+        scope_input_select = {ch: ch for ch in self._driver.active_channels}
+        sequencer_index = self._driver.active_channels[0]
+        sequencer_monitor_start_index = 64
+        trigger_input = (
+            sequencer_monitor_start_index + sequencer_index
+        )  # f"channel{sequencer_index}_sequencer_monitor0"
+        return (trigger_input, scope_input_select)
+
+
+class _SpectroscopyModeManager(ResultModeManager):
+    # Override
+    def validate_config(self) -> None:
+        if not self._driver._seqc_features.spectroscopy:
+            raise ziConfigurationError(
+                "The configured sequencer program is incompatible with the 'spectroscopy' result mode."
+            )
+
+    # Override
+    def extract_data(self, samples: int, data: dict = None) -> dict:
+        result = {}
+        for ch in self._driver.active_channels:
+            path = self._result_path(ch)
+            node_tree = data if data else self._driver.daq.get(path, flat=True)
+            result[ch] = _get_vector_from_node_tree(node_tree, path)
+        return result
+
+    # Override
+    def push_acquisition_unit_config(self) -> None:
+        for ch in self._driver.active_channels:
+            shfqa_utils.configure_result_logger_for_spectroscopy(
+                self._driver.daq,
+                self._driver.devname,
+                channel_index=ch,
+                result_length=self._driver._samples,
+                num_averages=self._driver._averages,
+                averaging_mode=_averaging_mode_to_int(self._driver._averaging_mode),
+            )
+            self._driver.set(
+                f"qachannels_{ch}_mode",
+                DeviceConstants.Spectroscopy.QACHANNEL_MODE,
+            )
+            self._driver.set(
+                f"qachannels_{ch}_spectroscopy_trigger_channel",
+                DeviceConstants.Spectroscopy.TRIGGER_SOURCE,
+            )
+            self._driver.set(
+                f"qachannels_{ch}_spectroscopy_delay", self._driver._wait_dly
+            )
+            self._driver.set(
+                f"qachannels_{ch}_spectroscopy_length",
+                duration_to_length(self._driver._acquisition_time),
+            )
+
+    # Override
+    def start_acquisition_units(self) -> None:
+        for ch in self._driver.active_channels:
+            shfqa_utils.enable_result_logger(
+                self._driver.daq,
+                self._driver.devname,
+                channel_index=ch,
+                mode="spectroscopy",
+            )
+
+    # Override
+    def wait_acquisition_units_finished(self) -> None:
+        for ch in self._driver.active_channels:
+            path = f"/{self._driver.devname}/qachannels/{ch}/spectroscopy/result/enable"
+            wait_for_state_change(
+                self._driver.daq, path, 0, timeout=self._driver.timeout()
+            )
+
+    # Override
+    def _acquisition_granularity(self) -> int:
+        return DeviceConstants.Spectroscopy.GRANULARITY
+
+    # Override
+    def _max_acquisition_length(self) -> int:
+        return DeviceConstants.Spectroscopy.MAX_LENGTH
+
+    # Override
+    def _result_path(self, ch: int, integrator: int = None) -> str:
+        return f"/{self._driver.devname}/qachannels/{ch}/spectroscopy/result/data/wave"
+
+
+def duration_to_length(duration: float) -> int:
+    """
+    Helper function converting a duration in seconds into number of samples on the device.
+    """
+    return int(round(duration * DeviceConstants.SAMPLING_FREQUENCY))
+
+
+def length_to_duration(length: int) -> float:
+    """
+    Helper function converting a number of samples on the device to a duration in seconds.
+    """
+    return length / DeviceConstants.SAMPLING_FREQUENCY
+
+
+def _get_vector_from_node_tree(node_tree: dict, path: str):
+    try:
+        return node_tree[path][0]["vector"]
+    except KeyError:
+        return None
+
+
+def _averaging_mode_to_int(averaging_mode: str) -> int:
+    if averaging_mode == "sequential":
+        return DeviceConstants.Averaging.SEQUENTIAL
+    if averaging_mode == "cyclic":
+        return DeviceConstants.Averaging.CYCLIC
+    _raise_unsupported_averaging_mode(averaging_mode)
+
+
+def _raise_unsupported_result_mode(result_mode: str) -> None:
+    raise ziValueError(
+        f"Unsupported result mode: {result_mode}. Supported modes are 'rl', 'ro' and 'spectroscopy'."
+    )
+
+
+def _raise_unsupported_averaging_mode(averaging_mode: str) -> None:
+    raise ziValueError(
+        f"Unsupported readout mode: {averaging_mode}. Supported modes are 'sequential' and 'cyclic'."
+    )

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa.py
@@ -1,0 +1,1463 @@
+"""
+To do:
+
+- Determine minimum revisions
+- Implement DIO.CalInterface
+- Calls to shfqa_utils also update Qcode parameters
+- Finish docstrings
+
+Notes:
+
+Changelog:
+"""
+
+import time
+import logging
+import numpy as np
+import os
+
+from typing import Tuple, List
+
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_instrument import (
+    ZI_base_instrument,
+    ziValueError,
+    ziVersionError,
+    ziDeviceError,
+    ziConfigurationError,
+)
+import pycqed.instrument_drivers.physical_instruments.ZurichInstruments.shfqa_uhfqc_compatibility as uhf_compatibility
+from pycqed.instrument_drivers.library.DIO import CalInterface
+
+from qcodes.utils import validators
+from qcodes.utils.helpers import full_class
+
+import zhinst.deviceutils.shfqa as shfqa_utils
+from zhinst.utils import wait_for_state_change
+
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.internal._shfqa import (
+    DeviceConstants,
+    UserRegisters,
+    SeqC,
+    preprocess_generator_waveform,
+    hold_off_length,
+    make_result_mode_manager,
+    duration_to_length,
+)
+
+log = logging.getLogger(__name__)
+
+
+class Defaults:
+    """
+    Class specifying driver default configuration values.
+    """
+
+    NUM_RESULTS = uhf_compatibility.Dio.MAX_NUM_RESULTS
+    NUM_MEASUREMENTS = 100
+    NUM_AVERAGES = 1
+
+    RESULT_MODE = "rl"
+    RESULT_SOURCE = "result_of_integration"
+
+    AVERAGING_MODE = "sequential"
+
+    ACQUISITION_TIME = 1000e-9
+    ACQUISITION_DELAY = 200e-9
+
+    DIGITAL_TRIGGER_SOURCE = "software_trigger0"
+
+    DIO_CALIBRATION_DELAY = 0
+
+    CODEWORD_MANAGER_INSTANCE = uhf_compatibility.BruteForceCodewordManager()
+
+    class SingleQubitExperiments:
+        """
+        Default values for single qubit experiments, (single readout pulse and integration weight).
+        """
+
+        CHANNEL = 0
+        SLOT = 0
+
+
+class SHFQA(ZI_base_instrument, CalInterface):
+    """
+    This is the PycQED driver for the 2.0 Gsample/s SHFQA developed
+    by Zurich Instruments.
+
+    Requirements:
+    Installation instructions for Zurich Instrument Libraries.
+    1. install ziPython 3.5/3.6 ucs4 19.05 for 64bit Windows from
+        http://www.zhinst.com/downloads, https://people.zhinst.com/~niels/
+    2. upload the latest firmware to the SHFQA using the LabOne GUI
+    """
+
+    def __init__(
+        self,
+        name,
+        device: str,
+        interface: str = "USB",
+        port: int = 8004,
+        use_dio: bool = True,
+        nr_integration_channels: int = Defaults.NUM_RESULTS,
+        codeword_manager=Defaults.CODEWORD_MANAGER_INSTANCE,
+        server: str = "127.0.0.1",
+        **kw,
+    ) -> None:
+        t0 = time.time()
+
+        self._codeword_manager = codeword_manager
+        self._use_dio = use_dio
+
+        super().__init__(
+            name=name,
+            device=device,
+            interface=interface,
+            server=server,
+            port=port,
+            num_codewords=2 ** nr_integration_channels,
+            **kw,
+        )
+
+        self._seqc_features = None
+        self._single = True
+        self._poll = True
+        self._result_mode_manager = None
+        self._active_slots = {}
+
+        self.load_default_settings(upload_sequence=False)
+
+        log.info(f"{self.devname}: Initialized SHFQA in {time.time() - t0:.3f}s")
+
+    ##########################################################################
+    # 'public' overrides for ZI_base_instrument
+    ##########################################################################
+
+    def start(self) -> None:
+        """
+        Starts the driver. In particular, cached configurations are validated and pushed to the device before arming
+        the acquisition units as well as the sequencers.
+        """
+        log.info(f"{self.devname}: Starting '{self.name}'")
+        self.check_errors()
+        if self._poll:
+            self._subscribe_to_result_nodes()
+        self.push_to_device()
+        self._enable_channels()
+        self._result_mode_manager.start_acquisition_units()
+        self._start_sequencers()
+
+    def stop(self) -> None:
+        """
+        Stops the driver. In particular, disarms active sequencers and checks for errors.
+        """
+        log.info(f"Stopping {self.name}")
+        for ch in self.active_channels:
+            self.set(f"qachannels_{ch}_generator_enable", 0)
+        self.unsubs()
+        self.check_errors()
+
+    def load_default_settings(self, upload_sequence: bool = True) -> None:
+        """
+        Sets default values to the QCoDes extra parameters. Note: these default settings are not pushed to the device.
+        They are only cached in the driver. Use the "push_to_device" method in order to upload the settings to the
+        instrument.
+
+        Args:
+            upload_sequencer: specify whether or not to upload a default sequencer program.
+        """
+        if upload_sequence:
+            self.awg_sequence_acquisition()
+
+        self.wait_dly(Defaults.ACQUISITION_DELAY)
+        self.dio_calibration_delay(Defaults.DIO_CALIBRATION_DELAY)
+
+        self.result_mode(Defaults.RESULT_MODE)
+        self.result_source(Defaults.RESULT_SOURCE)
+        self.acquisition_time(Defaults.ACQUISITION_TIME)
+        self.averages(Defaults.NUM_AVERAGES)
+        self.samples(Defaults.NUM_MEASUREMENTS)
+        self.averaging_mode(Defaults.AVERAGING_MODE)
+
+    def configure_awg_from_string(
+        self, awg_nr: int, program_string: str, timeout: float = 15
+    ) -> None:
+        """
+        Uploads the provided program string to the specified sequencer.
+
+        Args:
+            awg_nr: index of the sequencer to configure.
+            program_string: string specifying the SeqC program to upload.
+            timeout: time interval after which the upload is considered to have failed.
+
+        Raises:
+            TimeoutError: the upload was not successful even after the specified timeout.
+        """
+        shfqa_utils.load_sequencer_program(
+            self.daq,
+            self.devname,
+            channel_index=awg_nr,
+            sequencer_program=program_string,
+            timeout=self.timeout(),
+        )
+
+    def assure_ext_clock(self) -> None:
+        """
+        Attempts to lock the device to an external reference clock. Failure to lock does
+        not raise an exception.
+        """
+        external_source = 1
+        actual_source_path = "system/clocks/referenceclock/in/sourceactual"
+
+        is_already_locked = self.geti(actual_source_path) == external_source
+        if is_already_locked:
+            return
+        log.info(f"{self.devname}: Attempting to lock onto external reference clock...")
+        self.set("system_clocks_referenceclock_in_source", external_source)
+        try:
+            wait_for_state_change(
+                self.daq,
+                f"/{self.devname}/system/clocks/referenceclock/in/sourceactual",
+                value=external_source,
+                timeout=self.timeout(),
+            )
+            log.info(
+                f"{self.devname}: Successfully locked onto external reference clock."
+            )
+        except TimeoutError:
+            log.info(
+                f"{self.devname}: Failed to lock onto external reference clock within {self.timeout()}."
+            )
+
+    def clock_freq(self) -> float:
+        """
+        Returns the device clock frequency.
+        """
+        return DeviceConstants.SAMPLING_FREQUENCY
+
+    def plot_dio_snapshot(self, bits=range(32)) -> None:
+        raise NotImplementedError
+
+    ##########################################################################
+    # measurement setup methods ported from UHF
+    ##########################################################################
+
+    def acquisition(
+        self,
+        samples: int = Defaults.NUM_MEASUREMENTS,
+        averages: int = Defaults.NUM_AVERAGES,
+        acquisition_time: float = 0.010,
+        timeout: float = 10,
+        mode: str = Defaults.RESULT_MODE,
+        poll: bool = True,
+    ) -> dict:
+        """
+        Perform an acquisition from start to finish.
+
+        Args:
+            samples: number of measurement samples.
+            averages: number of averages per measurement sample.
+            acquisition_time: total time of the acquisition.
+            timeout: time specifying at which point the absence of results is considered an error.
+            mode: result mode with possible values 'rl', 'ro' or 'spectroscopy'.
+            poll: specify whether measurement results will under the hood be acquired via poll or deep get.
+        """
+        self.timeout(timeout)
+
+        self.acquisition_initialize(
+            samples=samples, averages=averages, mode=mode, poll=False
+        )
+
+        if poll:
+            data = self.acquisition_poll(
+                samples=samples, arm=True, acquisition_time=acquisition_time
+            )
+        else:
+            data = self.acquisition_get(
+                samples=samples, arm=True, acquisition_time=acquisition_time
+            )
+
+        self.acquisition_finalize()
+
+        return data
+
+    def acquisition_initialize(
+        self,
+        samples: int,
+        averages: int,
+        loop_cnt: int = None,
+        channels: tuple = (0, 1),  # ignored in this driver
+        mode: str = Defaults.RESULT_MODE,
+        poll: bool = True,
+    ) -> None:
+        """
+        Initializes the acquisition units with the provided measurement configration.
+
+        Args:
+            samples: number of measurement samples.
+            averages: number of averages per measurement sample.
+            loop_cnt: number of loop points to be configured for the sequencer program.
+            channels: (ignored)
+            mode: result mode with possible values 'rl', 'ro' or 'spectroscopy'
+            poll: specify whether to configure the device in a way that results may be collected using 'acquisition_poll'
+                  at the end of the measurement.
+        """
+        self.samples(samples)
+        self.averages(averages)
+        self.result_mode(mode)
+        self._poll = poll
+
+    def acquisition_arm(self, single=True) -> None:
+        """
+        Arms the acquisition.
+
+        Args:
+            single: specifies whether to disarm sequencers once all results have been collected.
+        """
+        self._single = single
+        self.start()
+
+    def acquisition_poll(self, samples, arm=True, acquisition_time=0.010) -> dict:
+        """
+        Returns the collected measurement results using the poll command under the hood. Note: this method does not
+        allow collecting partial results. Results will only be available if the acquisition units have been triggered
+        as many times as specified in the "acquisition_initialize" method. As opposed to "acquisition_get", this way of
+        acquiring results saves a redundant read request from the LabOne dataserver to the SHFQA at the end of the
+        experiment.
+
+        Args:
+            samples: number of expected measurement results. Mainly used to split scope segments if the acquisition mode
+                is set to "ro".
+            arm: specify whether or not to arm the acquisition before attempting to collect results.
+            acquisition_time: time during which to poll for results.
+
+        Raises:
+            TimeoutError: not all results as specified by the "acquisition_initialize" method could be collected.
+        """
+        if arm:
+            self.acquisition_arm()
+
+        accumulated_time = 0
+        gotem = False
+        while accumulated_time < self.timeout() and not gotem:
+            poll_result = self.poll(acquisition_time)
+            if poll_result:
+                result = self._result_mode_manager.extract_data(
+                    samples=samples, data=poll_result
+                )
+                if result:
+                    gotem = True
+            accumulated_time += acquisition_time
+
+        if not gotem:
+            self.acquisition_finalize()
+            raise TimeoutError("Failed to retrieve all acquisition results.")
+
+        return result
+
+    def acquisition_get(self, samples, arm=True, acquisition_time=0.010) -> dict:
+        """
+        Returns the collected measurement results using the get command under the hood. Note: this method does not
+        allow collecting partial results. Results will only be available if the acquisition units have been triggered
+        as many times as specified in the "acquisition_initialize" method.
+
+        Args:
+            samples: number of expected measurement results. Mainly used to split scope segments if the acquisition mode
+                     is set to "ro".
+            arm: specify whether or not to arm the acquisition before attempting to collect results.
+            acquisition_time: time during which to wait until the absence of results is considered an error.
+
+        TimeoutError: not all results as specified by the "acquisition_initialize" method could be collected.
+        """
+        if arm:
+            self.acquisition_arm()
+
+        if self._single:
+            try:
+                self._wait_sequencers_finished()
+            except TimeoutError:
+                self.acquisition_finalize()
+                raise TimeoutError(
+                    "Failed to retrieve acquisition results because sequencers are still running."
+                )
+
+        try:
+            self._result_mode_manager.wait_acquisition_units_finished()
+            result = self._result_mode_manager.extract_data(samples=samples, data=None)
+        except TimeoutError:
+            self.acquisition_finalize()
+            raise TimeoutError(
+                "Failed to retrieve acquisition results because acquisition units are still running."
+            )
+
+        return result
+
+    def acquisition_finalize(self) -> None:
+        """
+        Finalizes the current measurement.
+        """
+        self.stop()
+
+    ##########################################################################
+    # QCoDeS waveform parameters and their setters/getters
+    ##########################################################################
+
+    def _add_codeword_waveform_parameters(self, num_codewords) -> None:
+        """
+        Adds mutable QCoDeS parameters associating readout waveforms and codewords.
+
+        Args:
+            num_codewords: number specifying the range of codewords for which to define a waveform parameter.
+        """
+        log.info(f"{self.devname}: Adding codeword waveform parameters")
+        for codeword in range(num_codewords):
+            wf_name = _waveform_name(codeword)
+            if wf_name not in self.parameters:
+                self.add_parameter(
+                    wf_name,
+                    label=f"Waveform codeword {codeword}",
+                    vals=validators.Arrays(valid_types=(complex,)),
+                    set_cmd=self._write_waveform(codeword),
+                    get_cmd=self._read_waveform(codeword),
+                    docstring="Specifies a waveform for a specific codeword.",
+                )
+        self._num_codewords = num_codewords
+
+    def _csv_filename(self, codeword):
+        return os.path.join(
+            self._get_awg_directory(),
+            "waves",
+            self.devname + "_" + _waveform_name(codeword) + ".csv",
+        )
+
+    def _write_csv(self, codeword, waveform) -> None:
+        log.debug(f"{self.devname}: Writing waveform of codeword {codeword}")
+        np.savetxt(self._csv_filename(codeword), waveform)
+
+    def _read_csv(self, codeword):
+        filename = self._csv_filename(codeword)
+        try:
+            log.debug(
+                f"{self.devname}: reading codeword waveform {codeword} from csv '{filename}'"
+            )
+            waveform = np.genfromtxt(filename, dtype=np.complex128)
+            return waveform
+        except OSError as e:
+            # if the waveform does not exist yet dont raise exception
+            log.warning(e)
+            return None
+
+    def _write_waveform(self, codeword: int) -> None:
+        """
+        Returns the setter function for the QCoDeS waveform parameter associated to a given codeword.
+
+        Args:
+            codeword: codeword specifying which QCoDeS waveform parameter to associate the setter function to.
+        """
+
+        def write_func(waveform):
+            ch, slot = self._generator_slot(codeword)
+            waveform = preprocess_generator_waveform(waveform)
+            self._write_csv(codeword, waveform)
+
+        return write_func
+
+    def _read_waveform(self, codeword):
+        """
+        Returns the getter function for the QCoDeS waveform parameter associated to a given codeword.
+
+        Args:
+            codeword: codeword specifying which QCoDeS waveform parameter to associate the getter function to.
+        """
+
+        def read_func():
+            log.debug(f"{self.devname}: Reading waveform of codeword {codeword}")
+            ch, slot = self._generator_slot(codeword)
+            return self._read_csv(codeword)
+
+        return read_func
+
+    def _generator_slot(self, codeword: int) -> tuple:
+        """
+        Returns the channel and slot index specifying which generator memory slot a given codeword is associated with.
+
+        Args:
+            codeword: codeword from which to extract the memory slot.
+
+        Raises:
+            ziValueError: the codeword specifies either no generator memory slot at all, or multiple slots.
+        """
+        mapping = self._codeword_manager.codeword_slots(codeword)
+        if len(mapping) == 0:
+            raise ziValueError(
+                f"Cannot read/write waveform of codeword {codeword} because it is not associated to any generator slot. "
+                f"Only 'pure codeword waveforms', that is, codeword waveforms that are associated to a single generator, "
+                f"can be uploaded to the device."
+            )
+
+        multiple_slots_error = (
+            f"Cannot read/write waveform of codeword {codeword} because it is associated to multiple generator slots."
+            f"Only 'pure codeword waveforms', that is, codeword waveforms that are associated to a single generator, "
+            f"can be uploaded to the device."
+        )
+        spread_onto_multiple_channels = len(mapping) > 1
+        if spread_onto_multiple_channels:
+            raise ziValueError(multiple_slots_error)
+
+        for ch, slots in mapping.items():
+            spread_onto_multiple_slots = len(slots) > 1
+            if spread_onto_multiple_slots:
+                raise ziValueError(multiple_slots_error)
+            return ch, slots[0]
+
+    ##########################################################################
+    # extra QCoDeS parameters and their setters/getters
+    ##########################################################################
+
+    def _add_extra_parameters(self) -> None:
+        """
+        Adds extra QCoDes parameters to the driver instance. For a detailed description, please refer to the code below.
+        """
+        super()._add_extra_parameters()
+
+        ##########################################################################
+        # ported from UHF
+        ##########################################################################
+
+        self.add_parameter(
+            "wait_dly",
+            set_cmd=self._set_wait_dly,
+            get_cmd=self._get_wait_dly,
+            unit="",
+            label="Delay between the start of the output signal playback and integration at the input",
+            docstring="Configures a delay in seconds to be "
+            "applied between the start of the output signal playback and integration at the input",
+            vals=validators.Numbers(),
+        )
+
+        self.add_parameter(
+            "cases",
+            set_cmd=self._set_codewords,
+            get_cmd=self._get_codewords,
+            docstring="List of integers defining the codewords "
+            "to be handled by the sequencer program. For example, setting the parameter to [1, 5, 7] would result in "
+            "an AWG program that handles only codewords 1, 5 and 7. When running, if the AWG receives a codeword "
+            "that is not part of this list, an error will be triggered.",
+        )
+
+        self.add_parameter(
+            "dio_calibration_delay",
+            set_cmd=self._set_dio_calibration_delay,
+            get_cmd=self._get_dio_calibration_delay,
+            unit="",
+            label="DIO Calibration delay",
+            docstring="Configures the internal delay in 300 MHz cycles (3.3 ns) "
+            "to be applied on the DIO interface in order to achieve reliable sampling "
+            "of codewords. The valid range is 0 to 15.",
+            vals=validators.Ints(),
+        )
+
+        ##########################################################################
+        # specific to SHF
+        ##########################################################################
+
+        self.add_parameter(
+            "result_mode",
+            set_cmd=self._set_result_mode,
+            get_cmd=self._get_result_mode,
+            unit="",
+            label="Result mode",
+            docstring="Configures the result mode of the device. 'ro' records and returns the raw signal"
+            "at the channel inputs using the scope. 'rl' performs a weighted integration using the readout"
+            "units. 'spectroscopy' correlates the incoming signal with an internal oscillator whose frequency"
+            "can be swept to perform continuous wave of pulsed spectroscopy experiments."
+            " 'rl', 'spectroscopy'.",
+            vals=validators.Enum("ro", "rl", "spectroscopy"),
+        )
+
+        self.add_parameter(
+            "result_source",
+            set_cmd=self._set_result_source,
+            get_cmd=self._get_result_source,
+            unit="",
+            label="Result source",
+            docstring="Configures the result source in 'rl' mode of the device.",
+            vals=validators.Enum("result_of_integration", "result_of_discrimination"),
+        )
+
+        self.add_parameter(
+            "acquisition_time",
+            set_cmd=self._set_acquisition_time,
+            get_cmd=self._get_acquisition_time,
+            unit="",
+            label="Acquisition time",
+            docstring="Configures the acquisition time for each measurement in the experiment. The value will be "
+            "set to the instrument based on the acquisition mode, but only at the execution of of 'start()'",
+            vals=validators.Numbers(),
+        )
+
+        self.add_parameter(
+            "samples",
+            set_cmd=self._set_samples,
+            get_cmd=self._get_samples,
+            unit="",
+            label="Number of measurement samples",
+            docstring="Configures the number of measurement samples to acquire in the experiment.",
+            vals=validators.Ints(),
+        )
+
+        self.add_parameter(
+            "averages",
+            set_cmd=self._set_averages,
+            get_cmd=self._get_averages,
+            unit="",
+            label="Number of averages",
+            docstring="Configures the number of averages to be performed on the device for each measurement sample.",
+            vals=validators.Ints(),
+        )
+
+        self.add_parameter(
+            "averaging_mode",
+            set_cmd=self._set_averaging_mode,
+            get_cmd=self._get_averaging_mode,
+            unit="",
+            label="Averaging mode",
+            docstring="Configures the averaging algorithm performed on the device. Possible values: 'sequential' "
+            "and 'cyclic'.",
+            vals=validators.Enum("sequential", "cyclic"),
+        )
+
+    def _set_wait_dly(self, value: float) -> None:
+        """
+        Setter function for the "wait_dly" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._wait_dly = value
+
+    def _get_wait_dly(self) -> float:
+        """
+        Getter function for the "wait_dly" QCoDeS parameter.
+        """
+        return self._wait_dly
+
+    def _set_codewords(self, value) -> None:
+        """
+        Setter function for the "cases" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self.awg_sequence_acquisition_and_DIO_triggered_pulse(
+            Iwaves=None, Qwaves=None, cases=value
+        )
+
+    def _get_codewords(self) -> list:
+        """
+        Getter function for the "cases" QCoDeS parameter.
+        """
+        return self._codeword_manager.active_codewords
+
+    def _set_dio_calibration_delay(self, value) -> None:
+        """
+        Setter function for the "dio_calibration_delay" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        if value < 0 or value > 15:
+            raise ziValueError(
+                "Trying to set DIO calibration delay to invalid value! Expected value in range 0 to 15. Got {}.".format(
+                    value
+                )
+            )
+
+        log.info(f"{self.devname}: Setting DIO calibration delay to {value}")
+        self._dio_calibration_delay = value
+        # TODO this crashes for some reason
+        # self.setd("raw/dios/0/delay", self._dio_calibration_delay)
+
+    def _get_dio_calibration_delay(self) -> float:
+        """
+        Getter function for the "dio_calibration_delay" QCoDeS parameter.
+        """
+        return self._dio_calibration_delay
+
+    def _set_result_mode(self, value: str) -> None:
+        """
+        Setter function for the "result_mode" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._result_mode_manager = make_result_mode_manager(self, value)
+        self._result_mode = value
+
+    def _get_result_mode(self) -> float:
+        """
+        Getter function for the "result_mode" QCoDeS parameter.
+        """
+        return self._result_mode
+
+    def _set_result_source(self, value: str) -> None:
+        """
+        Setter function for the "result_source" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._result_source = value
+
+    def _get_result_source(self) -> float:
+        """
+        Getter function for the "result_source" QCoDeS parameter.
+        """
+        return self._result_source
+
+    def _set_acquisition_time(self, value: float) -> None:
+        """
+        Setter function for the "acquisition_time" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._acquisition_time = value
+
+    def _get_acquisition_time(self) -> float:
+        """
+        Getter function for the "acquisition_time" QCoDeS parameter.
+        """
+        return self._acquisition_time
+
+    def _set_samples(self, value: int) -> None:
+        """
+        Setter function for the "samples" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._samples = value
+
+    def _get_samples(self) -> int:
+        """
+        Getter function for the "samples" QCoDeS parameter.
+        """
+        return self._samples
+
+    def _set_averages(self, value: int) -> None:
+        """
+        Setter function for the "averages" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._averages = value
+
+    def _get_averages(self) -> int:
+        """
+        Getter function for the "averages" QCoDeS parameter.
+        """
+        return self._averages
+
+    def _set_averaging_mode(self, value: int) -> None:
+        """
+        Setter function for the "averaging_mode" QCoDeS parameter.
+
+        Args:
+            value: value to set the parameter to.
+        """
+        self._averaging_mode = value
+
+    def _get_averaging_mode(self) -> str:
+        """
+        Getter function for the "averaging_mode" QCoDeS parameter.
+        """
+        return self._averaging_mode
+
+    ##########################################################################
+    # Overriding Qcodes InstrumentBase methods
+    ##########################################################################
+
+    def snapshot_base(
+        self, update: bool = False, params_to_skip_update=None, params_to_exclude=None
+    ):
+        """
+        Returns QCoDes snapshot instance.
+
+        Args:
+            update: specify whether to query parameters from the instrument itself, or to use cached values.
+            params_to_skip_update: parameters for which to use cached values if update is set to True.
+            params_to_exclude: parameters to exclude all together.
+        """
+        if params_to_exclude is None:
+            params_to_exclude = set(
+                ["features_code", "system_fwlog", "system_fwlogenable"]
+            )
+
+        snap = {
+            "functions": {
+                name: func.snapshot(update=update)
+                for name, func in self.functions.items()
+            },
+            "submodules": {
+                name: subm.snapshot(update=update)
+                for name, subm in self.submodules.items()
+            },
+            "__class__": full_class(self),
+        }
+
+        snap["parameters"] = {}
+        for name, param in self.parameters.items():
+            if params_to_exclude and name in params_to_exclude:
+                pass
+            elif params_to_skip_update and name in params_to_skip_update:
+                update_par = False
+            else:
+                update_par = update
+                try:
+                    snap["parameters"][name] = param.snapshot(update=update_par)
+                except:
+                    logging.info(
+                        "Snapshot: Could not update parameter: {}".format(name)
+                    )
+                    snap["parameters"][name] = param.snapshot(update=False)
+
+        for attr in set(self._meta_attrs):
+            if hasattr(self, attr):
+                snap[attr] = getattr(self, attr)
+        return snap
+
+    ##########################################################################
+    # sequencer functions ported from UHFQC
+    ##########################################################################
+
+    def awg_sequence_acquisition_and_DIO_triggered_pulse(
+        self, Iwaves=None, Qwaves=None, cases=None, acquisition_delay: float = 0
+    ) -> None:
+        """
+        Configures the sequencers for a codeword experiment. The acquisition is started after receiving a DIO trigger,
+        with different generator and integrator slots being triggered based on the value of the codeword stored in the
+        DIO trigger value. The total number of readouts is specified by the variable stored in the "num_samples" user
+        register. Note: sets the "wait_dly", "cases" and codeword waveform QCoDes parameters.
+
+        Args:
+            Iwaves: real number arrays representing the in-phase components of the codeword waveforms. Overrides waveform
+                    parameters specified by the 'cases' argument. If cases is None, the waveforms will be mapped to
+                    default cases specified by the CodewordMapper instance provided to the driver during its initialization.
+            Qwaves: same as Iwaves, only for the quadrature components.
+            cases: list specifying which codewords to consider in the uploaded sequence. This list must be consistent
+                   with the provided waveforms, if provided.
+            acquisition_delay: time between the reception of the integration trigger and the actual integration.
+
+        Raises:
+            ziValueError: the provided cases list is not consistent with the provided waveforms.
+        """
+        if cases is not None:
+            self._codeword_manager.active_codewords = cases
+
+        self._active_slots = self._codeword_manager.active_slots()
+        codewords = self._codeword_manager.active_codewords
+
+        waves = None
+        if Iwaves is not None and Qwaves is not None:
+            waves = []
+            for i in range(len(Iwaves)):
+                waves.append(
+                    uhf_compatibility.check_and_convert_waveform(Iwaves[i], Qwaves[i])
+                )
+        elif Iwaves is not None or Qwaves is not None:
+            raise ziValueError("Must provide both Iwaves and Qwaves arguments.")
+
+        self.wait_dly(acquisition_delay)
+
+        if waves is not None:
+            if len(codewords) != len(waves):
+                raise ziValueError(
+                    f"Number of waves specified {len(waves)} does not match the number of currently active codewords "
+                    f"{len(codewords)}."
+                )
+            for i, wave in enumerate(waves):
+                self.set(_waveform_name(codewords[i]), wave)
+
+        switch_cases = [None] * len(self.active_channels)
+
+        for codeword in codewords:
+            for ch, slots in self._codeword_manager.codeword_slots(codeword).items():
+                try:
+                    switch_cases[ch][codeword] = slots
+                except TypeError:
+                    switch_cases[ch] = {codeword: slots}
+
+        for ch in self.active_channels:
+            features, program = SeqC.acquisition_and_DIO_triggered_pulse(
+                mask=uhf_compatibility.Dio.codeword_mask(),
+                shift=uhf_compatibility.Dio.INPUT_SHIFT,
+                cases=switch_cases[ch],
+            )
+            self._seqc_features = features
+            self._awg_program[ch] = program
+
+    ##########################################################################
+    # single qubit experiments
+    ##########################################################################
+
+    def awg_sequence_acquisition_and_pulse(
+        self,
+        Iwave=None,
+        Qwave=None,
+        acquisition_delay=0,
+        dig_trigger=True,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+        slot: int = Defaults.SingleQubitExperiments.SLOT,
+    ) -> None:
+        """
+        Configures the sequencers for an experiment where the acquisition is started after optionally receiving a
+        DIO trigger, with the readout pulse and integration weights stored in the specified generator and integrator
+        slot, respectively. The total number of readouts is specified by the variable stored in the "num_samples" user
+        register. Note: sets the "wait_dly" QCoDes parameter.
+
+        Args:
+            Iwave: real numbers array representing the in-phase component of the readout pulse
+            Qwave: real numbers array representing the quadrature component of the readout pulse
+            acquisition_delay: time between the reception of the integration trigger and the actual integration.
+            dig_trigger: specify whether or not the readout gets triggered through DIO.
+            ch: index specifying which qachannel to perform the experiment on.
+            slot: index specifying which generator and integrator slot to trigger for the experiment.
+        """
+        wave = uhf_compatibility.check_and_convert_waveform(Iwave, Qwave)
+
+        self._active_slots = {ch: [slot]}
+        self.wait_dly(acquisition_delay)
+
+        if wave is not None:
+            self.set(f"qachannels_{ch}_generator_waveforms_{slot}_wave", wave)
+
+        features, program = SeqC.acquisition_and_pulse(slot, dio_trigger=dig_trigger)
+        self._seqc_features = features
+        self._awg_program[ch] = program
+
+    def awg_sequence_acquisition(
+        self,
+        dly=0,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+        slot: int = Defaults.SingleQubitExperiments.SLOT,
+    ) -> None:
+        """
+        Configures the sequencers for an experiment where the acquisition is started after receiving a DIO trigger,
+        without playing any readout pulse and using the integration weights stored in a specified integrator slot. The
+        total number of readouts is specified by the variable stored in the "num_samples" user register. Note: sets
+        the "wait_dly" QCoDes parameter.
+
+        Args:
+            dly: time between the reception of the trigger and the actual integration.
+            ch: index specifying which qachannel to perform the experiment on.
+            slot: index specifying which integrator slot to trigger for the experiment.
+        """
+        self._active_slots = {ch: [slot]}
+        self.wait_dly(dly)
+
+        shfqa_utils.configure_sequencer_triggering(
+            self.daq,
+            self.devname,
+            channel_index=ch,
+            aux_trigger=Defaults.DIGITAL_TRIGGER_SOURCE,
+        )
+
+        features, program = SeqC.acquisition(slot)
+        self._seqc_features = features
+        self._awg_program[ch] = program
+
+    def awg_sequence_acquisition_and_pulse_SSB(
+        self,
+        f_RO_mod,
+        RO_amp,
+        RO_pulse_length,
+        acquisition_delay,
+        dig_trigger=True,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+        slot: int = Defaults.SingleQubitExperiments.SLOT,
+    ) -> None:
+        """
+        Same as 'awg_sequence_acquisition_and_pulse', only with an SSB readout pulse uploaded to the specified slot.
+        Args:
+            f_RO_mod: modulation frequency of the SSB readout pulse.
+            RO_amp: amplitude of the SSB readout pulse.
+            RO_pulse_length: length of the SSB readout pulse in seconds.
+            acquisition_delay: time between the reception of the integration trigger and the actual integration.
+            dig_trigger: specify whether or not the readout gets triggered through DIO.
+            ch: index specifying which qachannel to perform the experiment on.
+            slot: index specifying which generator and integrator slot to trigger for the experiment.
+        """
+        size = RO_pulse_length * DeviceConstants.SAMPLING_FREQUENCY
+        array = np.arange(int(size))
+        sin = RO_amp * np.sin(
+            2 * np.pi * array * f_RO_mod / DeviceConstants.SAMPLING_FREQUENCY
+        )
+        cos = RO_amp * np.cos(
+            2 * np.pi * array * f_RO_mod / DeviceConstants.SAMPLING_FREQUENCY
+        )
+
+        Iwave = (cos + sin) / np.sqrt(2)
+        Qwave = (cos - sin) / np.sqrt(2)
+
+        self.awg_sequence_acquisition_and_pulse(
+            Iwave, Qwave, acquisition_delay, dig_trigger=dig_trigger, ch=ch, slot=slot
+        )
+
+    def configure_spectroscopy(
+        self,
+        start_frequency: float,
+        frequency_step: float,
+        settling_time: float,
+        dio_trigger: bool = True,
+        envelope=None,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+    ) -> None:
+        """
+        Configures a sequencer-based continuous or pulsed spectroscopy experiment on the specified channel, where each step
+        may be triggered via DIO. The number of frequency steps and averages is specified by the variables stored in the
+        "num_samples" and "num_averages" user register, respectively.
+
+        Args:
+            start_frequency: starting point of the frequency sweep
+            frequency_step: offset added to the previous frequency value at each new step
+            settling_time: interval in seconds between the frequency setting and the start of the acquisition.
+            dio_trigger: specify whether the different frequency steps are self-triggered, or via a DIO trigger.
+            envelope: optional complex array parameter specifying the envelope to be applied to the resonator excitation.
+                      If set to None, a continuous wave (CW) spectroscopy experiment will be performed.
+            ch: index specifying which qachannel to perform the experiment on.
+        """
+        self.wait_dly(settling_time)
+        self._active_slots = {ch: [Defaults.SingleQubitExperiments.SLOT]}
+
+        if envelope is not None:
+            self.set(
+                f"qachannels_{ch}_spectroscopy_envelope_enable",
+                1,
+            )
+            self.set(
+                f"qachannels_{ch}_spectroscopy_envelope",
+                envelope,
+            )
+        else:
+            self.set(
+                f"qachannels_{ch}_spectroscopy_envelope_enable",
+                0,
+            )
+
+        features, program = SeqC.spectroscopy(
+            start_frequency, frequency_step, dio_trigger=dio_trigger
+        )
+        self._seqc_features = features
+        self._awg_program[ch] = program
+
+    def awg_sequence_acquisition_and_DIO_RED_test(
+        self,
+        acquisition_delay=0,
+        dio_out_vect=None,
+    ) -> None:
+        raise NotImplementedError
+
+    def awg_sequence_test_pattern(self, dio_out_vect=None) -> None:
+        raise NotImplementedError
+
+    def spec_mode_on(
+        self, acq_length=1 / 1500, IF=20e6, ro_amp=0.1, wint_length=2 ** 14
+    ) -> None:
+        raise NotImplementedError(
+            "Use the method 'configure_spectroscopy' and the 'spectroscopy' tag in the corresponding 'acquisition_...' "
+            "methods to specify a spectroscopy experiment."
+        )
+
+    ##########################################################################
+    # weighted integration helpers ported from UHF
+    ##########################################################################
+
+    def prepare_SSB_weight_and_rotation(
+        self,
+        IF: float,
+        rotation_angle: float = 0,
+        length: float = DeviceConstants.Readout.MAX_LENGTH
+        / DeviceConstants.SAMPLING_FREQUENCY,
+        scaling_factor: float = 1,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+        slot: int = Defaults.SingleQubitExperiments.SLOT,
+    ) -> None:
+        """
+        Uploads SSB integration weights to a specified integrator slot.
+
+        Args:
+            IF: demodulation frequency.
+            rotation_angle: rotation to apply to the weights.
+            length: duration in seconds of the weights function.
+            scaling_factor: additional scaling factor to apply to the weight function.
+            ch: index specifying the qachannel.
+            slot: index specifying which integrator slot to upload the weight function to.
+        """
+        # to be consistent in naming
+        duration = length
+        if duration_to_length(duration) > DeviceConstants.Readout.MAX_LENGTH:
+            raise ziValueError(
+                f"SSB integration weights of duration {duration} exceed the maximum readout length of "
+                f"{DeviceConstants.Readout.MAX_LENGTH}"
+            )
+        tbase = np.arange(
+            0,
+            duration,
+            1 / DeviceConstants.SAMPLING_FREQUENCY,
+        )
+        cos = scaling_factor * np.array(np.cos(2 * np.pi * IF * tbase + rotation_angle))
+        sin = scaling_factor * np.array(np.sin(2 * np.pi * IF * tbase + rotation_angle))
+        weight = cos - 1j * sin
+
+        self.set(f"qachannels_{ch}_readout_integration_weights_{slot}_wave", weight)
+
+    def prepare_DSB_weight_and_rotation(
+        self,
+        IF: float,
+        ch: int = Defaults.SingleQubitExperiments.CHANNEL,
+        slot: int = Defaults.SingleQubitExperiments.SLOT,
+    ) -> None:
+        raise NotImplementedError
+
+    ##########################################################################
+    # overrides for CalInterface interface
+    ##########################################################################
+
+    def output_dio_calibration_data(
+        self, dio_mode: str, port: int = 0
+    ) -> Tuple[int, List]:
+        raise NotImplementedError
+
+    def calibrate_dio_protocol(
+        self, dio_mask: int, expected_sequence: List, port: int = 0
+    ):
+        raise NotImplementedError
+
+    ##########################################################################
+    # Overriding private ZI_base_instrument methods
+    ##########################################################################
+
+    def _check_devtype(self) -> None:
+        if "SHFQA" not in self.devtype:
+            raise ziDeviceError(
+                f"Device {self.devname} of type {self.devtype} is not a SHFQA instrument!"
+            )
+
+    def _check_options(self) -> None:
+        pass
+
+    def _check_versions(self) -> None:
+        if self.geti("system/fwrevision") < DeviceConstants.MinRevisions.FW:
+            raise ziVersionError(
+                f"Insufficient firmware revision detected! Need {DeviceConstants.MinRevisions.FW}, "
+                f'got {self.geti("system/fwrevision")}!'
+            )
+        if self.geti("system/fpgarevision") < DeviceConstants.MinRevisions.FPGA:
+            raise ziVersionError(
+                f"Insufficient FPGA revision detected! Need {DeviceConstants.MinRevisions.FPGA}, "
+                f'got {self.geti("system/fpgarevision")}!'
+            )
+
+    def _check_awg_nr(self, awg_nr: int) -> None:
+        if awg_nr > self._num_channels():
+            raise ziValueError(f"Invalid AWG index of {awg_nr} detected!")
+
+    def _num_channels(self) -> int:
+        if self.devtype == "SHFQA4":
+            return 4
+        return 2
+
+    def _num_awgs(self) -> int:
+        return self._num_channels()
+
+    ##########################################################################
+    # properties
+    ##########################################################################
+
+    @property
+    def active_slots(self) -> dict:
+        """
+        Returns the currently active slots in the driver.
+        """
+        if not self._active_slots:
+            log.debug(
+                log.debug(
+                    f"{self.devname}: No slots are currently active. Make sure to setup an experimental "
+                    f"sequence on the awg to pursue."
+                )
+            )
+        return self._active_slots
+
+    @property
+    def active_channels(self) -> tuple:
+        """
+        Returns the currently active channels in the driver.
+        """
+        return tuple(ch for ch, slots in self.active_slots.items())
+
+    ##########################################################################
+    # startup helpers
+    ##########################################################################
+
+    def validate_config(self):
+        """
+        Top level function validating currently stored driver configuration. Can be used e.g. before actually pushing
+        data to the device.
+        """
+        if self._seqc_features is None:
+            raise ziConfigurationError("Missing awg sequence.")
+        if not self._active_slots:
+            raise ziConfigurationError("No readout units are active.")
+        self._result_mode_manager.validate_config()
+
+    def _push_sequencer_programs(self) -> None:
+        """
+        Uploads the cached sequencer programs corresponding to the currently active channels to the device.
+        """
+        for ch in self.active_channels:
+            if self._awg_program[ch] is None:
+                raise ziConfigurationError(
+                    f"No sequencer program defined for active channel {ch}."
+                )
+            self.configure_awg_from_string(
+                awg_nr=ch, program_string=self._awg_program[ch]
+            )
+
+    def _push_waveforms(self) -> None:
+        """
+        Uploads the currently active codewords to the device.
+        """
+        if not self._seqc_features.codewords:
+            return
+        for codeword in self._codeword_manager.active_codewords:
+            try:
+                waveform = self.get(_waveform_name(codeword))
+                ch, slot = self._generator_slot(codeword)
+                log.debug(
+                    f"{self.devname}: Uploading {codeword} to slot {slot} of generator {ch}."
+                )
+                self.set(f"qachannels_{ch}_generator_waveforms_{slot}_wave", waveform)
+            except ziValueError:
+                pass
+
+    def _push_hold_off_delay(self):
+        for ch in self.active_channels:
+            path = f"qachannels_{ch}_generator_userregs_"
+            self.set(
+                f"{path}{UserRegisters.HOLDOFF_DELAY}",
+                hold_off_length(self._acquisition_time + self._wait_dly),
+            )
+
+    def _push_loop_config(self):
+        loop_sizes = self._loop_sizes()
+        for ch in self.active_channels:
+            path = f"qachannels_{ch}_generator_userregs_"
+            self.set(
+                f"{path}{UserRegisters.INNER_LOOP}",
+                loop_sizes.inner,
+            )
+            self.set(
+                f"{path}{UserRegisters.OUTER_LOOP}",
+                loop_sizes.outer,
+            )
+
+    def push_to_device(self):
+        """
+        Top level function responsible for pushing the shallow device configuration stored in the driver to the actual
+        device.
+        """
+        self.validate_config()
+
+        if self._use_dio:
+            self._configure_codeword_protocol()
+
+        self._push_sequencer_programs()
+        self._push_waveforms()
+        self._push_loop_config()
+        self._push_hold_off_delay()
+
+        self._result_mode_manager.push_acquisition_unit_config()
+
+    def _enable_channels(self) -> None:
+        """
+        Enables the RF frontends corresponding to the currently active channels.
+        """
+        for ch in self.active_channels:
+            path = f"qachannels_{ch}_"
+            self.set(path + "input_on", 1)
+            self.set(path + "output_on", 1)
+
+    def _start_sequencers(self) -> None:
+        """
+        Starts the sequencers of the currently active channels.
+        """
+        for ch in self.active_channels:
+            shfqa_utils.enable_sequencer(
+                self.daq,
+                self.devname,
+                channel_index=ch,
+                single=1 if self._single else 0,
+            )
+
+    ##########################################################################
+    # experiment control helpers
+    ##########################################################################
+
+    def _wait_sequencers_finished(self) -> None:
+        """
+        Blocks until the currently active sequencers have stopped execution.
+
+        Args:
+            timeout: timeout specifying at which point sequencers that are still running are considered an error.
+
+        Raises:
+            TimeoutError: sequencers are still running after the specified timeout.
+        """
+        for ch in self.active_channels:
+            generator_path = (
+                f"/{self.devname}/qachannels/{ch}/generator/sequencer/status"
+            )
+            wait_for_state_change(self.daq, generator_path, 0, timeout=self.timeout())
+
+    ##########################################################################
+    # setup helpers
+    ##########################################################################
+
+    def _subscribe_to_result_nodes(self) -> None:
+        """
+        Subscribes to the device nodes containing measurement results specific to the current result mode.
+        """
+        self._subscribed_paths = []
+        for path in self._result_mode_manager.result_paths():
+            self.subs(path)
+            self._subscribed_paths.append(path)
+
+    def _configure_codeword_protocol(self) -> None:
+        """
+        Configures the device to work with the central controller DIO paradigm.
+        """
+        dio_path = "dios_0_"
+        self.set(dio_path + "mode", uhf_compatibility.Dio.MODE)
+        self.set(dio_path + "drive", uhf_compatibility.Dio.DRIVE)
+        for ch in self.active_channels:
+            generator_dio_path = f"qachannels_{ch}_generator_dio_"
+            self.set(
+                generator_dio_path + "valid_polarity",
+                uhf_compatibility.Dio.VALID_POLARITY,
+            )
+            self.set(
+                generator_dio_path + "valid_index", uhf_compatibility.Dio.VALID_INDEX
+            )
+
+    def _loop_sizes(self) -> SeqC.LoopSizes:
+        if not self._seqc_features.outer_loop:
+            return SeqC.LoopSizes(inner=self._samples * self._averages, outer=0)
+        if self._averaging_mode == "sequential":
+            return SeqC.LoopSizes(inner=self._averages, outer=self._samples)
+        if self._averaging_mode == "cyclic":
+            return SeqC.LoopSizes(inner=self._samples, outer=self._averages)
+        raise ziConfigurationError
+
+    ##########################################################################
+    # 'public' utility functions ported from UHF
+    ##########################################################################
+
+    def reset_acquisition_params(self) -> None:
+        self.reset_user_registers()
+        self.reset_crosstalk_matrix()
+        self.reset_correlation_params()
+
+    def reset_user_registers(self) -> None:
+        default_value = 0
+        log.info(f"{self.devname}: Setting user registers to {default_value}")
+        for ch in self.active_channels:
+            for userreg_index in range(DeviceConstants.NUM_REGISTERS_PER_SEQUENCER):
+                self.set(
+                    f"qachannels_{ch}_generator_userregs_{userreg_index}",
+                    default_value,
+                )
+
+    def reset_crosstalk_matrix(self) -> None:
+        raise NotImplementedError("Crosstalk suppression is not available on SHFQA.")
+
+    def reset_correlation_params(self) -> None:
+        default_value = 0
+        for ch, slots in self.active_slots.items():
+            for slot in slots:
+                self.set(
+                    f"qachannels_{ch}_readout_discriminators_{slot}_threshold",
+                    default_value,
+                )
+        log.info(f"{self.devname}: Correlation is not yet implemented")
+
+    def reset_rotation_params(self) -> None:
+        raise NotImplementedError(
+            "Rotation of the integration weights is not supported by the SHFQA. Please include such corrections in the weights uploaded to the instrument."
+        )
+
+    def upload_crosstalk_matrix(self, matrix) -> None:
+        raise NotImplementedError("Crosstalk suppression is not available on SHFQA.")
+
+    def download_crosstalk_matrix(self, nr_rows=10, nr_cols=10) -> None:
+        raise NotImplementedError("Crosstalk suppression is not available on SHFQA.")
+
+    ##########################################################################
+    # 'public' print overview functions ported from UHF
+    ##########################################################################
+
+    def print_correlation_overview(self) -> None:
+        raise NotImplementedError("Crosstalk suppression is not available on SHFQA.")
+
+    def print_deskew_overview(self) -> None:
+        raise NotImplementedError(
+            "Input deskew is not available on the SHFQA, as the rf down-conversion is performed in-the-box."
+        )
+
+    def print_crosstalk_overview(self) -> None:
+        raise NotImplementedError("Crosstalk suppression is not available on SHFQA.")
+
+    def print_integration_overview(self) -> None:
+        raise NotImplementedError
+
+    def print_rotations_overview(self) -> None:
+        raise NotImplementedError(
+            "Rotation of the integration weights is not supported by the SHFQA. Please include such corrections in the weights uploaded to the instrument."
+        )
+
+    def print_thresholds_overview(self) -> None:
+        msg = "\t Thresholds overview \n"
+        for ch, slots in self.active_slots.items():
+            for slot in slots:
+                path = f"qachannels/{ch}/readout/discriminators/{slot}/threshold"
+                msg += f"Channel {ch} Threshold {slot}: {self.getd(path)}"
+        print(msg)
+
+    def print_user_regs_overview(self) -> None:
+        msg = "\t User registers overview \n"
+        user_reg_funcs = [""] * DeviceConstants.NUM_REGISTERS_PER_SEQUENCER
+        user_reg_funcs[UserRegisters.INNER_LOOP] = SeqC._VAR_INNER_LOOP_SIZE
+        user_reg_funcs[UserRegisters.OUTER_LOOP] = SeqC._VAR_OUTER_LOOP_SIZE
+        user_reg_funcs[UserRegisters.NUM_ERRORS] = SeqC._VAR_NUM_ERRORS
+
+        for ch in self.active_channels:
+            for userreg_index in range(DeviceConstants.NUM_REGISTERS_PER_SEQUENCER):
+                value = self.geti(f"qachannels/{ch}/generator/userregs/{userreg_index}")
+                func = user_reg_funcs[userreg_index]
+                msg += f"Sequencer {ch} User reg {userreg_index}: \t{value}\t({func})\n"
+        print(msg)
+
+    def print_overview(self) -> None:
+        self.print_integration_overview()
+        self.print_thresholds_overview()
+        self.print_user_regs_overview()
+
+
+def _waveform_name(codeword: int) -> str:
+    """
+    Returns a waveform name based on codeword number.
+
+    Args:
+        codeword: value of the codeword to use for the waveform name generation.
+    """
+    return "wave_cw{:03}".format(codeword)

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa_codewords.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa_codewords.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+
+
+class CodewordManager(ABC):
+    """
+    Abstract base class used to specify mappings between codewords and generator+integrator
+    slots on the SHFQA.
+    """
+
+    def __init__(self):
+        self._active_codewords = self._default_active_codewords()
+
+    @property
+    def active_codewords(self) -> list:
+        """
+        Property specifying which codewords will actually be considered in an experimental sequence.
+        """
+        return self._active_codewords
+
+    @active_codewords.setter
+    def active_codewords(self, codewords) -> None:
+        """
+        Setter of the 'active_codewords' property.
+        """
+        self._active_codewords = list(codewords)
+
+    def active_slots(self) -> dict:
+        """
+        Returns a dictionary specifying which generators slots of the device
+        are currently active. Specifically, this method accumulates the results from
+        'codeword_slots()' over all stored codewords.
+        """
+        result = {}
+        for codeword in self.active_codewords:
+            for ch, slots in self.codeword_slots(codeword).items():
+                try:
+                    for slot in slots:
+                        result[ch].append(slot)
+                except KeyError:
+                    result[ch] = slots
+        return result
+
+    def codeword_slots(self, codeword: int) -> dict:
+        """
+        Returns a dictionary specifying which generator slots a specified codeword
+        will trigger in an experiment.
+        """
+        self._check_codeword(codeword)
+        return self._codeword_slots(codeword)
+
+    @abstractmethod
+    def _codeword_slots(self, codeword: int) -> dict:
+        """
+        Customization point of public 'codeword_slots' method. Returns a dictionary specifying which generator
+        slots a specified codeword will trigger in an experiment.
+        """
+        pass
+
+    @abstractmethod
+    def _default_active_codewords(self) -> list:
+        """
+        Returns a list of default codewords for the specified mapping.
+        """
+        pass
+
+    @abstractmethod
+    def _check_num_results(self, num_results: int) -> None:
+        """
+        Validator checking whether the provided number of results is compatible with the specified codeword mapping.
+        """
+        pass
+
+    @abstractmethod
+    def _check_codeword(self, codeword: int) -> None:
+        """
+        Validator checking whether the provided codeword is compatible with the specified codeword mapping.
+        """
+        pass
+
+    class Error(Exception):
+        """
+        Exception raised in a context of wrong handling of codewords.
+        """
+
+        pass

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa_uhfqc_compatibility.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/shfqa_uhfqc_compatibility.py
@@ -1,0 +1,140 @@
+"""Module collecting functionality relative to easing the transition from UHFQC to SHFQA."""
+
+import numpy as np
+import logging
+
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.ZI_base_instrument import (
+    ziConfigurationError,
+    ziValueError,
+)
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.shfqa_codewords import (
+    CodewordManager,
+)
+from pycqed.instrument_drivers.physical_instruments.ZurichInstruments.internal._shfqa import (
+    preprocess_generator_waveform,
+)
+
+log = logging.getLogger(__name__)
+
+
+class Dio:
+    """
+    Class collecting functionality relating to the UHFQA DIO compatibility mode under one namespace.
+    """
+
+    MODE = 17  # UHFQA compatibility mode
+    VALID_POLARITY = 2  # high polarity
+    VALID_INDEX = 16
+    DRIVE = 0x3
+
+    MAX_NUM_CHANNELS = 2
+    MAX_NUM_RESULTS_PER_CHANNEL = 7
+    MAX_NUM_RESULTS = MAX_NUM_CHANNELS * MAX_NUM_RESULTS_PER_CHANNEL
+    MAX_NUM_CODEWORDS = 2 ** MAX_NUM_RESULTS
+
+    "               <---- Input ----> <--- Output --->"
+    _CW_MASK_STR = "01111111 11111110 00000000 00000000"
+    "                <-ch2-> <-ch1->"
+    INPUT_SHIFT = 17
+
+    @staticmethod
+    def codeword_mask() -> int:
+        """
+        Returns an integer mask allowing to extract a codeword from a DIO trigger value.
+        """
+        binary_mask_str = Dio._CW_MASK_STR.replace(" ", "")
+        return int("".join(bit for bit in binary_mask_str), 2)
+
+    @staticmethod
+    def check_num_results(num_results: int) -> None:
+        """
+        Checks whether the provided number of results is compatible with the DIO compatibility mode.
+
+        Args:
+            num_results: total number of results to be checked
+
+        Raises:
+            ziConfigurationError: the number of results is incompatible.
+        """
+        if num_results > Dio.MAX_NUM_RESULTS:
+            raise ziConfigurationError(
+                f"The UHFQA DIO compatibility mode on the SHFQA only supports up to "
+                f"{Dio.MAX_NUM_RESULTS} results!"
+            )
+
+    @staticmethod
+    def check_codeword(codeword: int) -> None:
+        """
+        Checks whether the provided codeword is compatible with the DIO compatibility mode.
+
+        Args:
+            codeword: codeword to be checked
+
+        Raises:
+            ziConfigurationError: the provided codeword is incompatible.
+
+        """
+        if codeword > Dio.MAX_NUM_CODEWORDS:
+            raise ziConfigurationError(
+                f"The UHFQA DIO compatibility mode on the SHFQA only supports up to "
+                f"{Dio.MAX_NUM_CODEWORDS} codewords!"
+            )
+
+
+class BruteForceCodewordManager(CodewordManager):
+    """
+    Default "brute force" mapping between codewords and generators: each specified
+    codeword is assigned to a single generator in ascending order. Supports a maximum
+    of Dio.MAX_NUM_RESULTS codewords simultaneously.
+    """
+
+    # Override
+    def _codeword_slots(self, codeword: int) -> dict:
+        Dio.check_codeword(codeword)
+        try:
+            result_index = self._active_codewords.index(codeword)
+        except ValueError:
+            raise CodewordManager.Error(
+                "Trying to access a codeword in BruteForceCodewordManager that was not set."
+            )
+        ch, slot = divmod(result_index, Dio.MAX_NUM_RESULTS_PER_CHANNEL)
+        return {ch: [slot]}
+
+    # Override
+    def _check_num_results(self, num_results: int) -> None:
+        Dio.check_num_results(num_results)
+
+    # Override
+    def _check_codeword(self, codeword) -> None:
+        Dio.check_codeword(codeword)
+
+    # Override
+    def _default_active_codewords(self) -> list:
+        return range(Dio.MAX_NUM_RESULTS)
+
+
+def check_and_convert_waveform(Iwave, Qwave) -> None:
+    """
+    Validates a pair of real arrays candidate for upload onto a generator slot of the SHFQA. The function
+    additionally snaps the length of the array to the granularity of the generator.
+
+    Args:
+        Iwave: real numbers array representing the in-phase component of a candidate complex waveform to be uploaded
+               to a device generator slot.
+        Qwave: real numbers array representing the quadrature component of a candidate complex waveform to be uploaded
+               to a device generator slot.
+    """
+    if Iwave is not None and Qwave is not None:
+        Iwave = preprocess_generator_waveform(Iwave)
+        Qwave = preprocess_generator_waveform(Qwave)
+        if not (len(Iwave) == len(Iwave)):
+            raise ziValueError(
+                f"Length of I component {len(Iwave)} does not match length of Q component {len(Qwave)}"
+            )
+        return np.array([Iwave[i] + 1j * Qwave[i] for i in range(len(Iwave))])
+    elif Iwave is not None:
+        Iwave = preprocess_generator_waveform(Iwave)
+        return np.array(Iwave)
+    elif Qwave is not None:
+        Qwave = preprocess_generator_waveform(Qwave)
+        return np.array([1j * Qwave[i] for i in range(len(Qwave))])

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/zi_parameter_files/node_doc_SHFQA2.json
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/zi_parameter_files/node_doc_SHFQA2.json
@@ -1,0 +1,3572 @@
+{
+    "clockbase": {
+        "Description": "Returns the internal clock frequency of the device.",
+        "Node": "clockbase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "dios/0/drive": {
+        "Description": "When on (1), the corresponding 8-bit bus is in output mode. When off (0), it is in input mode. Bit 0 corresponds to the least significant byte. For example, the value 1 drives the least significant byte, the value 8 drives the most significant byte.",
+        "Node": "dios/0/drive",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/input": {
+        "Description": "Gives the value of the DIO input for those bytes where drive is disabled.",
+        "Node": "dios/0/input",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/interface": {
+        "Description": "Selects the interface standard to use on the 32-bit DIO interface. A value of 0 means that a 3.3 V CMOS interface is used. A value of 1 means that an LVDS compatible interface is used.",
+        "Node": "dios/0/interface",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/mode": {
+        "Description": "Select DIO mode",
+        "Node": "dios/0/mode",
+        "Options": {
+            "0": "\"manual\": Enables manual control of the DIO output bits.",
+            "16": "\"qa_result\": Sends discriminated readout results to the DIO.",
+            "32": "\"chan0seq\", \"channel0_sequencer\": Enables control of DIO values by the sequencer of channel 1.",
+            "33": "\"chan1seq\", \"channel1_sequencer\": Enables control of DIO values by the sequencer of channel 2."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "dios/0/output": {
+        "Description": "Sets the value of the DIO output for those bytes where 'drive' is enabled.",
+        "Node": "dios/0/output",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "features/code": {
+        "Description": "Node providing a mechanism to write feature codes.",
+        "Node": "features/code",
+        "Properties": "Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/devtype": {
+        "Description": "Returns the device type.",
+        "Node": "features/devtype",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/options": {
+        "Description": "Returns enabled options.",
+        "Node": "features/options",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/serial": {
+        "Description": "Device serial number.",
+        "Node": "features/serial",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "qachannels/0/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/0/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/0/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/0/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/0/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/0/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/0/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/0/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/0/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/0/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/0/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/0/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/0/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/0/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/0/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/0/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/0/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/0/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/0/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/0/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/0/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/0/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/0/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/0/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/0/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/0/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/0/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/0/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/0/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/0/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/0/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/0/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/0/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/0/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/0/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/0/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/0/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/0/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/0/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/0/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/0/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/0/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/0/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/0/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/0/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/0/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/0/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/0/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/0/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/0/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/0/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/0/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/0/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/0/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/0/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/0/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/0/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/0/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/0/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/0/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/0/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/0/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/0/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/0/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/0/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/0/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/0/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/0/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/0/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/0/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/0/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/0/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/1/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/1/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/1/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/1/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/1/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/1/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/1/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/1/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/1/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/1/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/1/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/1/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/1/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/1/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/1/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/1/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/1/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/1/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/1/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/1/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/1/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/1/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/1/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/1/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/1/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/1/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/1/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/1/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/1/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/1/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/1/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/1/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/1/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/1/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/1/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/1/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/1/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/1/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/1/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/1/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/1/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/1/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/1/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/1/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/1/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/1/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/1/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/1/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/1/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/1/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/1/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/1/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/1/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/1/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/1/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/1/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/1/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/1/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/1/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/1/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/1/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/1/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/1/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/1/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/1/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/1/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/1/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/1/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/1/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/1/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/1/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/averaging/count": {
+        "Description": "Configures the number of Scope measurements to average.",
+        "Node": "scopes/0/averaging/count",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/averaging/enable": {
+        "Description": "Enables averaging of Scope measurements.",
+        "Node": "scopes/0/averaging/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/0/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/0/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/0/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/0/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/0/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/1/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/1/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/1/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/1/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/1/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/2/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/2/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/2/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/2/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/2/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/3/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/3/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/3/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/3/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/3/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/enable": {
+        "Description": "Enables the acquisition of Scope shots. Goes back to 0 (disabled) after the scope shot has been acquired.",
+        "Node": "scopes/0/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/length": {
+        "Description": "Defines the length of the recorded Scope shot in number of samples.",
+        "Node": "scopes/0/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/segments/count": {
+        "Description": "Specifies the number of segments to be recorded in device memory. The maximum Scope shot size is given by the available memory divided by the number of segments.",
+        "Node": "scopes/0/segments/count",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/segments/enable": {
+        "Description": "Enable segmented Scope recording. This allows for full bandwidth recording of Scope shots with a minimum dead time between individual shots.",
+        "Node": "scopes/0/segments/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/single": {
+        "Description": "Puts the Scope into single shot mode.",
+        "Node": "scopes/0/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/time": {
+        "Description": "Defines the time base of the Scope.",
+        "Node": "scopes/0/time",
+        "Options": {
+            "0": "2 GHz"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/trigger/channel": {
+        "Description": "Selects the trigger source signal.",
+        "Node": "scopes/0/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "64": "\"chan0seqmon0\", \"channel0_sequencer_monitor0\": Channel 1, Sequencer Monitor Trigger.",
+            "65": "\"chan1seqmon0\", \"channel1_sequencer_monitor0\": Channel 2, Sequencer Monitor Trigger."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/trigger/delay": {
+        "Description": "The delay of a Scope measurement. A negative delay results in data being acquired before the trigger point. The resolution is 2 ns.",
+        "Node": "scopes/0/trigger/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "scopes/0/trigger/enable": {
+        "Description": "When triggering is enabled scope data are acquired every time the defined trigger condition is met.",
+        "Node": "scopes/0/trigger/enable",
+        "Options": {
+            "0": "\"off\": OFF: Continuous scope shot acquisition",
+            "1": "\"on\": ON: Trigger based scope shot acquisition"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/bandwidth": {
+        "Description": "Command streaming bandwidth usage on the physical network connection between device and data server.",
+        "Node": "stats/cmdstream/bandwidth",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Mbit/s"
+    },
+    "stats/cmdstream/bytesreceived": {
+        "Description": "Number of bytes received on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/bytesreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/cmdstream/bytessent": {
+        "Description": "Number of bytes sent on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/bytessent",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/cmdstream/packetslost": {
+        "Description": "Number of command packets lost since device start. Command packets contain device settings that are sent to and received from the device.",
+        "Node": "stats/cmdstream/packetslost",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/packetsreceived": {
+        "Description": "Number of packets received on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/packetsreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/packetssent": {
+        "Description": "Number of packets sent on the command stream to the device since session start.",
+        "Node": "stats/cmdstream/packetssent",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/pending": {
+        "Description": "Number of buffers ready for receiving command packets from the device.",
+        "Node": "stats/cmdstream/pending",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/processing": {
+        "Description": "Number of buffers being processed for command packets. Small values indicate proper performance. For a TCP/IP interface, command packets are sent using the TCP protocol.",
+        "Node": "stats/cmdstream/processing",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/bandwidth": {
+        "Description": "Data streaming bandwidth usage on the physical network connection between device and data server.",
+        "Node": "stats/datastream/bandwidth",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Mbit/s"
+    },
+    "stats/datastream/bytesreceived": {
+        "Description": "Number of bytes received on the data stream from the device since session start.",
+        "Node": "stats/datastream/bytesreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/datastream/packetslost": {
+        "Description": "Number of data packets lost since device start. Data packets contain measurement data.",
+        "Node": "stats/datastream/packetslost",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/packetsreceived": {
+        "Description": "Number of packets received on the data stream from the device since session start.",
+        "Node": "stats/datastream/packetsreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/pending": {
+        "Description": "Number of buffers ready for receiving data packets from the device.",
+        "Node": "stats/datastream/pending",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/processing": {
+        "Description": "Number of buffers being processed for data packets. Small values indicate proper performance. For a TCP/IP interface, data packets are sent using the UDP protocol.",
+        "Node": "stats/datastream/processing",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/physical/currents/0": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/1": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/2": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/3": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/4": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/fanspeeds/0": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/0",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/1": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/1",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/2": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/2",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/3": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/3",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/4": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/4",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/5": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/5",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fpga/aux": {
+        "Description": "Supply voltage of the FPGA.",
+        "Node": "stats/physical/fpga/aux",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/fpga/core": {
+        "Description": "Core voltage of the FPGA.",
+        "Node": "stats/physical/fpga/core",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/fpga/pstemp": {
+        "Description": "Internal temperature of the FPGA's processor system.",
+        "Node": "stats/physical/fpga/pstemp",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/fpga/temp": {
+        "Description": "Internal temperature of the FPGA.",
+        "Node": "stats/physical/fpga/temp",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/overtemperature": {
+        "Description": "This flag is set to a value greater than 0 when the internal temperatures are reaching critical limits.",
+        "Node": "stats/physical/overtemperature",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/physical/sigins/0/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/0/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/0/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/1/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/1/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/currents/0": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/1": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/2": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/3": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/4": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/4": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/voltages/0": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/1": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/10": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/2": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/3": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/4": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/5": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/6": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/7": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/8": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/9": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/temperatures/0": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/1": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/2": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/3": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/4": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/5": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/6": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/7": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/voltages/0": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/1": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/2": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/3": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/4": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "status/adc0max": {
+        "Description": "The maximum value on Signal Input 1 (ADC0) during 100 ms.",
+        "Node": "status/adc0max",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc0min": {
+        "Description": "The minimum value on Signal Input 1 (ADC0) during 100 ms",
+        "Node": "status/adc0min",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc1max": {
+        "Description": "The maximum value on Signal Input 2 (ADC1) during 100 ms.",
+        "Node": "status/adc1max",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc1min": {
+        "Description": "The minimum value on Signal Input 2 (ADC1) during 100 ms",
+        "Node": "status/adc1min",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/fifolevel": {
+        "Description": "USB FIFO level: Indicates the USB FIFO fill level inside the device. When 100%, data is lost",
+        "Node": "status/fifolevel",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "status/flags/binary": {
+        "Description": "A set of binary flags giving an indication of the state of various parts of the device. Reserved for future use.",
+        "Node": "status/flags/binary",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/flags/packetlosstcp": {
+        "Description": "Flag indicating if tcp packages have been lost.",
+        "Node": "status/flags/packetlosstcp",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/flags/packetlossudp": {
+        "Description": "Flag indicating if udp packages have been lost.",
+        "Node": "status/flags/packetlossudp",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/time": {
+        "Description": "The current timestamp.",
+        "Node": "status/time",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/activeinterface": {
+        "Description": "Currently active interface of the device.",
+        "Node": "system/activeinterface",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/boardrevisions/0": {
+        "Description": "Hardware revision of the motherboard containing the FPGA.",
+        "Node": "system/boardrevisions/0",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/boardrevisions/1": {
+        "Description": "Hardware revision of the Signal Output board.",
+        "Node": "system/boardrevisions/1",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/freq": {
+        "Description": "Indicates the frequency of the reference clock.",
+        "Node": "system/clocks/referenceclock/in/freq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "system/clocks/referenceclock/in/source": {
+        "Description": "The intended reference clock source. When the source is changed, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/in/source",
+        "Options": {
+            "0": "\"internal\": The internal clock is intended to be used as the frequency and time base reference.",
+            "1": "\"external\": An external clock is intended to be used as the frequency and time base reference. Provide a clean and stable 10 MHz or 100 MHz reference to the appropriate back panel connector.",
+            "2": "\"zsync\": The ZSync clock is intended to be used as the frequency and time base reference."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/sourceactual": {
+        "Description": "The actual reference clock source.",
+        "Node": "system/clocks/referenceclock/in/sourceactual",
+        "Options": {
+            "0": "\"internal\": The internal clock is used as the frequency and time base reference.",
+            "1": "\"external\": An external clock is used as the frequency and time base reference.",
+            "2": "\"zsync\": The ZSync clock is used as the frequency and time base reference."
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/status": {
+        "Description": "Status of the reference clock.",
+        "Node": "system/clocks/referenceclock/in/status",
+        "Options": {
+            "0": "Reference clock has been locked on.",
+            "1": "There was an error locking onto the reference clock signal.",
+            "2": "The device is busy trying to lock onto the reference clock signal."
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/out/enable": {
+        "Description": "Enable clock signal on the reference clock output. When the clock output is turned on or off, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/out/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/out/freq": {
+        "Description": "Select the frequency of the output reference clock. Only 10 MHz and 100 MHz are allowed. When the frequency is changed, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/out/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "system/fpgarevision": {
+        "Description": "HDL firmware revision.",
+        "Node": "system/fpgarevision",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/fwlog": {
+        "Description": "Returns log output of the firmware.",
+        "Node": "system/fwlog",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/fwlogenable": {
+        "Description": "Enables logging to the fwlog node.",
+        "Node": "system/fwlogenable",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/fwrevision": {
+        "Description": "Revision of the device-internal controller software.",
+        "Node": "system/fwrevision",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/identify": {
+        "Description": "Setting this node to 1 will cause all frontpanel LEDs to blink for 5 seconds, then return to their previous state.",
+        "Node": "system/identify",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/interfacespeed": {
+        "Description": "Speed of the currently active interface (USB only).",
+        "Node": "system/interfacespeed",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultgateway": {
+        "Description": "Default gateway configuration for the network connection.",
+        "Node": "system/nics/0/defaultgateway",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultip4": {
+        "Description": "IPv4 address of the device to use if static IP is enabled.",
+        "Node": "system/nics/0/defaultip4",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultmask": {
+        "Description": "IPv4 mask in case of static IP.",
+        "Node": "system/nics/0/defaultmask",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/gateway": {
+        "Description": "Current network gateway.",
+        "Node": "system/nics/0/gateway",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/ip4": {
+        "Description": "Current IPv4 of the device.",
+        "Node": "system/nics/0/ip4",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/mac": {
+        "Description": "Current MAC address of the device network interface.",
+        "Node": "system/nics/0/mac",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/mask": {
+        "Description": "Current network mask.",
+        "Node": "system/nics/0/mask",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/saveip": {
+        "Description": "If written, this action will program the defined static IP address to the device.",
+        "Node": "system/nics/0/saveip",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/nics/0/static": {
+        "Description": "Enable this flag if the device is used in a network with fixed IP assignment without a DHCP server.",
+        "Node": "system/nics/0/static",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/owner": {
+        "Description": "Returns the current owner of the device (IP).",
+        "Node": "system/owner",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/properties/freqresolution": {
+        "Description": "The number of bits used to represent a frequency.",
+        "Node": "system/properties/freqresolution",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/properties/freqscaling": {
+        "Description": "The scale factor to use to convert a frequency represented as a freqresolution-bit integer to a floating point value.",
+        "Node": "system/properties/freqscaling",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/maxfreq": {
+        "Description": "The maximum oscillator frequency that can be set.",
+        "Node": "system/properties/maxfreq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/maxtimeconstant": {
+        "Description": "The maximum demodulator time constant that can be set.",
+        "Node": "system/properties/maxtimeconstant",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/minfreq": {
+        "Description": "The minimum oscillator frequency that can be set.",
+        "Node": "system/properties/minfreq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/mintimeconstant": {
+        "Description": "The minimum demodulator time constant that can be set.",
+        "Node": "system/properties/mintimeconstant",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/negativefreq": {
+        "Description": "Indicates whether negative frequencies are supported.",
+        "Node": "system/properties/negativefreq",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/properties/timebase": {
+        "Description": "Minimal time difference between two timestamps. The value is equal to 1/(maximum sampling rate).",
+        "Node": "system/properties/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "system/shutdown": {
+        "Description": "Sending a '1' to this node initiates a shutdown of the operating system on the device. It is recommended to trigger this shutdown before switching the device off with the hardware switch at the back side of the device.",
+        "Node": "system/shutdown",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/stall": {
+        "Description": "Indicates if the network connection is stalled.",
+        "Node": "system/stall",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/swtriggers/0/single": {
+        "Description": "Issues a single software trigger event.",
+        "Node": "system/swtriggers/0/single",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/update": {
+        "Description": "Requests update of the device firmware and bitstream from the dataserver.",
+        "Node": "system/update",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    }
+}

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/zi_parameter_files/node_doc_SHFQA4.json
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/zi_parameter_files/node_doc_SHFQA4.json
@@ -1,0 +1,7344 @@
+{
+    "clockbase": {
+        "Description": "Returns the internal clock frequency of the device.",
+        "Node": "clockbase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "dios/0/drive": {
+        "Description": "When on (1), the corresponding 8-bit bus is in output mode. When off (0), it is in input mode. Bit 0 corresponds to the least significant byte. For example, the value 1 drives the least significant byte, the value 8 drives the most significant byte.",
+        "Node": "dios/0/drive",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/input": {
+        "Description": "Gives the value of the DIO input for those bytes where drive is disabled.",
+        "Node": "dios/0/input",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/interface": {
+        "Description": "Selects the interface standard to use on the 32-bit DIO interface. A value of 0 means that a 3.3 V CMOS interface is used. A value of 1 means that an LVDS compatible interface is used.",
+        "Node": "dios/0/interface",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "dios/0/mode": {
+        "Description": "Select DIO mode",
+        "Node": "dios/0/mode",
+        "Options": {
+            "0": "\"manual\": Enables manual control of the DIO output bits.",
+            "16": "\"qa_result\": Sends discriminated readout results to the DIO.",
+            "32": "\"chan0seq\", \"channel0_sequencer\": Enables control of DIO values by the sequencer of channel 1.",
+            "33": "\"chan1seq\", \"channel1_sequencer\": Enables control of DIO values by the sequencer of channel 2.",
+            "34": "\"chan2seq\", \"channel2_sequencer\": Enables control of DIO values by the sequencer of channel 3.",
+            "35": "\"chan3seq\", \"channel3_sequencer\": Enables control of DIO values by the sequencer of channel 4."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "dios/0/output": {
+        "Description": "Sets the value of the DIO output for those bytes where 'drive' is enabled.",
+        "Node": "dios/0/output",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "features/code": {
+        "Description": "Node providing a mechanism to write feature codes.",
+        "Node": "features/code",
+        "Properties": "Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/devtype": {
+        "Description": "Returns the device type.",
+        "Node": "features/devtype",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/options": {
+        "Description": "Returns enabled options.",
+        "Node": "features/options",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "features/serial": {
+        "Description": "Device serial number.",
+        "Node": "features/serial",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "qachannels/0/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/0/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/0/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/0/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/0/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/0/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/0/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/0/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/0/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/0/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/0/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/0/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/0/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/0/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/0/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/0/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/0/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/0/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/0/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/0/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/0/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/0/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/0/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/0/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/0/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/0/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/10/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/10/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/10/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/11/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/11/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/11/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/12/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/12/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/12/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/13/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/13/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/13/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/14/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/14/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/14/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/15/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/15/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/15/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/8/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/8/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/8/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/9/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/0/generator/waveforms/9/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/generator/waveforms/9/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/0/generator/waveforms/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/0/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/0/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/0/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/0/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/0/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/0/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/0/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/0/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/0/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/0/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/0/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/0/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/0/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/0/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/0/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/10/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/10/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/11/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/11/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/12/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/12/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/13/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/13/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/14/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/14/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/15/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/15/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/8/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/8/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/discriminators/9/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/0/readout/discriminators/9/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/0/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/0/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/0/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/10/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/11/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/12/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/13/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/14/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/15/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/8/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/integration/weights/9/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/0/readout/integration/weights/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/0/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/0/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/10/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/10/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/11/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/11/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/12/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/12/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/13/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/13/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/14/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/14/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/15/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/15/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/8/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/8/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/data/9/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/0/readout/result/data/9/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/0/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/0/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/0/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/0/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/0/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/0/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/0/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/0/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/0/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/0/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/0/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/0/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/0/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/0/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/0/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/0/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/0/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/0/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/0/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/0/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/0/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/0/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/0/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/0/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/0/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/0/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/0/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/0/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/0/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/0/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/1/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/1/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/1/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/1/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/1/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/1/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/1/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/1/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/1/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/1/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/1/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/1/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/1/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/1/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/1/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/1/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/1/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/1/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/1/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/1/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/1/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/1/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/1/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/1/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/1/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/10/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/10/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/10/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/11/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/11/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/11/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/12/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/12/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/12/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/13/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/13/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/13/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/14/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/14/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/14/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/15/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/15/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/15/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/8/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/8/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/8/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/9/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/1/generator/waveforms/9/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/generator/waveforms/9/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/1/generator/waveforms/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/1/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/1/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/1/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/1/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/1/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/1/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/1/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/1/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/1/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/1/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/1/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/1/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/1/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/1/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/1/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/10/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/10/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/11/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/11/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/12/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/12/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/13/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/13/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/14/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/14/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/15/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/15/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/8/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/8/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/discriminators/9/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/1/readout/discriminators/9/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/1/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/1/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/1/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/10/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/11/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/12/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/13/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/14/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/15/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/8/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/integration/weights/9/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/1/readout/integration/weights/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/1/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/1/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/10/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/10/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/11/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/11/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/12/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/12/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/13/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/13/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/14/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/14/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/15/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/15/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/8/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/8/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/data/9/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/1/readout/result/data/9/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/1/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/1/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/1/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/1/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/1/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/1/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/1/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/1/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/1/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/1/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/1/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/1/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/1/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/1/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/1/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/1/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/1/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/1/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/1/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/1/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/1/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/1/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/1/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/1/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/1/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/1/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/1/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/1/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/1/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/1/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/2/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/2/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/2/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/2/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/2/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/2/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/2/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/2/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/2/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/2/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/2/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/2/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/2/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/2/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/2/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/2/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/2/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/2/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/2/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/2/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/2/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/2/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/2/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/2/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/2/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/2/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/10/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/10/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/10/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/11/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/11/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/11/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/12/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/12/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/12/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/13/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/13/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/13/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/14/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/14/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/14/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/15/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/15/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/15/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/8/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/8/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/8/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/9/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/2/generator/waveforms/9/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/generator/waveforms/9/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/2/generator/waveforms/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/2/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/2/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/2/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/2/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/2/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/2/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/2/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/2/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/2/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/2/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/2/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/2/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/2/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/2/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/2/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/10/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/10/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/11/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/11/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/12/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/12/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/13/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/13/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/14/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/14/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/15/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/15/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/8/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/8/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/discriminators/9/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/2/readout/discriminators/9/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/2/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/2/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/2/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/2/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/10/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/11/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/12/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/13/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/14/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/15/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/8/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/integration/weights/9/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/2/readout/integration/weights/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/2/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/2/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/10/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/10/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/11/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/11/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/12/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/12/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/13/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/13/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/14/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/14/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/15/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/15/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/8/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/8/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/data/9/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/2/readout/result/data/9/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/2/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/2/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/2/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/2/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/2/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/2/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/2/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/2/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/2/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/2/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/2/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/2/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/2/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/2/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/2/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/2/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/2/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/2/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/2/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/2/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/2/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/2/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/2/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/2/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/2/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/2/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/2/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/2/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/2/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/2/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/2/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/2/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/centerfreq": {
+        "Description": "The Center Frequency of the analysis band.",
+        "Node": "qachannels/3/centerfreq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/3/generator/auxtriggers/0/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/3/generator/auxtriggers/0/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/auxtriggers/1/channel": {
+        "Description": "Selects the source of the digital Trigger.",
+        "Node": "qachannels/3/generator/auxtriggers/1/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/clearwave": {
+        "Description": "Clears all waveforms in each slot and resets their length to 0.",
+        "Node": "qachannels/3/generator/clearwave",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/delay": {
+        "Description": "Sets a common delay for the start of the playback for all Waveform Memories. The resolution is 2 ns.",
+        "Node": "qachannels/3/generator/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/3/generator/dio/data": {
+        "Description": "A vector of 32-bit integers representing the values on the DIO interface.",
+        "Node": "qachannels/3/generator/dio/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/dio/valid/index": {
+        "Description": "Select the DIO bit to use as the VALID signal to indicate that a valid input is available.",
+        "Node": "qachannels/3/generator/dio/valid/index",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/dio/valid/polarity": {
+        "Description": "Polarity of the VALID bit that indicates that a valid input is available.",
+        "Node": "qachannels/3/generator/dio/valid/polarity",
+        "Options": {
+            "0": "\"none\": None: VALID bit is ignored.",
+            "1": "\"low\": Low: VALID bit must be logical zero.",
+            "2": "\"high\": High: VALID bit must be logical high.",
+            "3": "\"both\": Both: VALID bit may be logical high or zero."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/elf/data": {
+        "Description": "Content of the uploaded ELF file.",
+        "Node": "qachannels/3/generator/elf/data",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/elf/length": {
+        "Description": "Length of the compiled ELF file.",
+        "Node": "qachannels/3/generator/elf/length",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/elf/name": {
+        "Description": "Name of the uploaded ELF file.",
+        "Node": "qachannels/3/generator/elf/name",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/elf/progress": {
+        "Description": "Percentage of the Sequencer program already uploaded to the device.",
+        "Node": "qachannels/3/generator/elf/progress",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "%"
+    },
+    "qachannels/3/generator/enable": {
+        "Description": "Enables the Sequencer.",
+        "Node": "qachannels/3/generator/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/ready": {
+        "Description": "The Sequencer has a compiled program and is ready to be enabled.",
+        "Node": "qachannels/3/generator/ready",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/reset": {
+        "Description": "Clears the configured Sequencer program and resets the state to not ready.",
+        "Node": "qachannels/3/generator/reset",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/clear": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/clear",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/data": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/data",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/enable": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/input": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/input",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/mode": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/mode",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/starttimestamp": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/starttimestamp",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/status": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/rtlogger/timebase": {
+        "Description": "[empty]",
+        "Node": "qachannels/3/generator/rtlogger/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/sequencer/assembly": {
+        "Description": "Displays the current sequence program in compiled form. Every line corresponds to one hardware instruction and requires one clock cycle (4.0 ns) for execution.",
+        "Node": "qachannels/3/generator/sequencer/assembly",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/sequencer/memoryusage": {
+        "Description": "Size of the current Sequencer program relative to the available instruction memory of 16384 instructions.",
+        "Node": "qachannels/3/generator/sequencer/memoryusage",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/sequencer/program": {
+        "Description": "Displays the source code of the current Sequencer program.",
+        "Node": "qachannels/3/generator/sequencer/program",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/sequencer/status": {
+        "Description": "Status of the Sequencer on the instrument. Bit 0: Sequencer is running; Bit 1: reserved; Bit 2: Sequencer is waiting for a trigger to arrive; Bit 3: Sequencer has detected an error.",
+        "Node": "qachannels/3/generator/sequencer/status",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/sequencer/triggered": {
+        "Description": "When at value 1, indicates that the Sequencer has been triggered.",
+        "Node": "qachannels/3/generator/sequencer/triggered",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/single": {
+        "Description": "Puts the Sequencer into single-shot mode.",
+        "Node": "qachannels/3/generator/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/0": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/0",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/1": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/1",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/10": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/10",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/11": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/11",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/12": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/12",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/13": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/13",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/14": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/14",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/15": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/15",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/2": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/2",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/3": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/3",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/4": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/4",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/5": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/5",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/6": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/6",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/7": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/7",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/8": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/8",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/userregs/9": {
+        "Description": "Integer user register value. The sequencer has read and write access to the user register values during runtime.",
+        "Node": "qachannels/3/generator/userregs/9",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/0/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/0/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/0/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/1/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/1/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/1/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/10/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/10/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/10/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/11/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/11/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/11/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/12/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/12/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/12/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/13/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/13/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/13/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/14/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/14/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/14/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/15/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/15/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/15/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/2/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/2/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/2/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/3/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/3/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/3/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/4/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/4/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/4/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/5/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/5/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/5/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/6/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/6/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/6/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/7/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/7/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/7/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/8/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/8/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/8/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/9/length": {
+        "Description": "Length of the uploaded waveform in number of complex samples.",
+        "Node": "qachannels/3/generator/waveforms/9/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/generator/waveforms/9/wave": {
+        "Description": "Contains the generators waveforms as a vector of complex samples",
+        "Node": "qachannels/3/generator/waveforms/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/input/on": {
+        "Description": "Enables the Signal Input.",
+        "Node": "qachannels/3/input/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/input/overrangecount": {
+        "Description": "Indicates the number of times the Signal Input was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/3/input/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/input/range": {
+        "Description": "Sets the maximal Range of the Signal Input power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/3/input/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/3/markers/0/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/3/markers/0/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/markers/1/source": {
+        "Description": "Selects the source for the marker output.",
+        "Node": "qachannels/3/markers/1/source",
+        "Options": {
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "128": "\"chan0rod\", \"channel0_readout_done\": Channel 1, Readout done.",
+            "129": "\"chan1rod\", \"channel1_readout_done\": Channel 2, Readout done.",
+            "130": "\"chan2rod\", \"channel2_readout_done\": Channel 3, Readout done.",
+            "131": "\"chan3rod\", \"channel3_readout_done\": Channel 4, Readout done.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/mode": {
+        "Description": "Selects between Spectroscopy and Qubit Readout mode.",
+        "Node": "qachannels/3/mode",
+        "Options": {
+            "0": "\"spectroscopy\": In Spectroscopy mode, the Signal Output is connected to the Oscillator, with which also the measured signals are correlated.",
+            "1": "\"readout\": In Qubit Readout mode, the Signal Output is connected to the Readout Pulse Generator, and the measured signals are correlated with the Integration Weights before state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/oscs/0/freq": {
+        "Description": "Controls the frequency of each digital Oscillator.",
+        "Node": "qachannels/3/oscs/0/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "qachannels/3/oscs/0/gain": {
+        "Description": "Controls the gain of each digital Oscillator. The gain is defined relative to the Output Range of the Readout Channel.",
+        "Node": "qachannels/3/oscs/0/gain",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/output/filter": {
+        "Description": "Reads the selected analog filter before the Signal Output.",
+        "Node": "qachannels/3/output/filter",
+        "Options": {
+            "0": "\"lowpass_1500\": Low-pass filter of 1.5 GHz.",
+            "1": "\"lowpass_3000\": Low-pass filter of 3 GHz.",
+            "2": "\"bandpass_3000_6000\": Band-pass filter between 3 GHz - 6 GHz",
+            "3": "\"bandpass_6000_10000\": Band-pass filter between 6 GHz - 10 GHz"
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/output/on": {
+        "Description": "Enables the Signal Output.",
+        "Node": "qachannels/3/output/on",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/output/overrangecount": {
+        "Description": "Indicates the number of times the Signal Output was in an overrange condition within the last 200 ms. It is checked for an overrange condition every 10 ms.",
+        "Node": "qachannels/3/output/overrangecount",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/output/range": {
+        "Description": "Sets the maximal Range of the Signal Output power. The instrument selects the closest available Range with a resolution of 5 dBm.",
+        "Node": "qachannels/3/output/range",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "dBm"
+    },
+    "qachannels/3/readout/discriminators/0/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/0/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/1/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/1/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/10/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/10/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/11/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/11/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/12/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/12/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/13/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/13/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/14/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/14/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/15/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/15/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/2/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/2/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/3/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/3/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/4/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/4/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/5/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/5/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/6/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/6/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/7/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/7/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/8/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/8/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/discriminators/9/threshold": {
+        "Description": "Sets the threshold level for the 2-state discriminator on the real signal axis in Vs.",
+        "Node": "qachannels/3/readout/discriminators/9/threshold",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/clearweight": {
+        "Description": "Clears all integration weights by setting them to 0.",
+        "Node": "qachannels/3/readout/integration/clearweight",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/delay": {
+        "Description": "Sets a common delay for the start of the readout integration for all Integration Weights with respect to the time when the trigger is received. The resolution is 2 ns.",
+        "Node": "qachannels/3/readout/integration/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/3/readout/integration/length": {
+        "Description": "Sets the length of all Integration Weights in number of samples. A maximum of 4096 samples can be integrated, which corresponds to 2.05 us.",
+        "Node": "qachannels/3/readout/integration/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/0/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/0/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/1/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/1/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/10/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/10/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/11/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/11/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/12/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/12/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/13/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/13/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/14/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/14/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/15/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/15/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/2/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/2/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/3/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/3/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/4/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/4/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/5/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/5/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/6/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/6/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/7/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/7/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/8/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/8/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/integration/weights/9/wave": {
+        "Description": "Contains the complex-valued waveform of the Integration Weight. The valid range is between -1.0 and +1.0 for both the real and imaginary part.",
+        "Node": "qachannels/3/readout/integration/weights/9/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/3/readout/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/3/readout/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/0/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/1/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/10/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/10/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/11/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/11/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/12/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/12/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/13/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/13/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/14/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/14/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/15/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/15/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/2/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/3/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/4/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/4/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/5/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/5/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/6/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/6/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/7/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/7/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/8/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/8/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/data/9/wave": {
+        "Description": "Acquired result data. Depending on the source of the data, the data can be complex- or integer-valued.",
+        "Node": "qachannels/3/readout/result/data/9/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/enable": {
+        "Description": "Enables the acquisition of readout results.",
+        "Node": "qachannels/3/readout/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/3/readout/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/3/readout/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/3/readout/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/overdio": {
+        "Description": "Number of DIO interface overflows during readout. This can happen if readouts are triggered faster than the maximum possible data-rate of the DIO interface.",
+        "Node": "qachannels/3/readout/result/overdio",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/readout/result/source": {
+        "Description": "Selects the signal source of the Result Logger.",
+        "Node": "qachannels/3/readout/result/source",
+        "Options": {
+            "1": "\"result_of_integration\": Complex-valued integration results of the Weighted Integration in Qubit Readout mode.",
+            "3": "\"result_of_discrimination\": The results after state discrimination."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/delay": {
+        "Description": "Sets the delay of the integration in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/3/spectroscopy/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/3/spectroscopy/envelope/delay": {
+        "Description": "Sets the delay of the envelope waveform in Spectroscopy mode with respect to the Trigger signal. The resolution is 2 ns.",
+        "Node": "qachannels/3/spectroscopy/envelope/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "qachannels/3/spectroscopy/envelope/enable": {
+        "Description": "Enables the modulation of the oscillator signal with the complex envelope waveform.",
+        "Node": "qachannels/3/spectroscopy/envelope/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/envelope/length": {
+        "Description": "Length of the uploaded envelope waveform in number of complex samples.",
+        "Node": "qachannels/3/spectroscopy/envelope/length",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/envelope/wave": {
+        "Description": "Contains the envelope waveform as a vector of complex samples.",
+        "Node": "qachannels/3/spectroscopy/envelope/wave",
+        "Properties": "Read, Write",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/length": {
+        "Description": "Sets the integration length in Spectroscopy mode in number of samples. Up to 33.5 MSa (2^25 samples) can be recorded, which corresponds to 16.7 ms.",
+        "Node": "qachannels/3/spectroscopy/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/acquired": {
+        "Description": "Indicates the index of the acquisition that will be performed on the next trigger.",
+        "Node": "qachannels/3/spectroscopy/result/acquired",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/averages": {
+        "Description": "Number of measurements that are averaged. Only powers of 2 are valid, other values are rounded down to the next power of 2. 1 means no averaging. The maximum setting is 32768.",
+        "Node": "qachannels/3/spectroscopy/result/averages",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/data/wave": {
+        "Description": "Acquired complex spectroscopy result data.",
+        "Node": "qachannels/3/spectroscopy/result/data/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/enable": {
+        "Description": "Enables the acquisition of spectroscopy results.",
+        "Node": "qachannels/3/spectroscopy/result/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/errors": {
+        "Description": "Number of hold-off errors detected since last reset.",
+        "Node": "qachannels/3/spectroscopy/result/errors",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/length": {
+        "Description": "Number of data points to record. One data point corresponds to a single averaged result value of the selected source.",
+        "Node": "qachannels/3/spectroscopy/result/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/result/mode": {
+        "Description": "Selects the averaging order of the result.",
+        "Node": "qachannels/3/spectroscopy/result/mode",
+        "Options": {
+            "0": "\"cyclic\": Cyclic averaging: a sequence of multiple results is recorded first, then averaged with the next repetition of the same sequence.",
+            "1": "\"sequential\": Sequential averaging: each result is recorded and averaged first, before the next result is recorded and averaged."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/spectroscopy/trigger/channel": {
+        "Description": "Selects the source of the trigger for the integration and envelope in Spectroscopy mode.",
+        "Node": "qachannels/3/spectroscopy/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/triggers/0/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/3/triggers/0/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/triggers/0/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/3/triggers/0/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/3/triggers/0/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/3/triggers/0/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "qachannels/3/triggers/1/imp50": {
+        "Description": "Trigger Input impedance: When on, the Trigger Input impedance is 50 Ohm; when off, 1 kOhm.",
+        "Node": "qachannels/3/triggers/1/imp50",
+        "Options": {
+            "0": "\"1_kOhm\": OFF: 1 k Ohm",
+            "1": "\"50_Ohm\": ON: 50 Ohm"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "qachannels/3/triggers/1/level": {
+        "Description": "Defines the analog Trigger level.",
+        "Node": "qachannels/3/triggers/1/level",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "qachannels/3/triggers/1/value": {
+        "Description": "Shows the value of the digital Trigger Input. The value is integrated over a period of 100 ms. Values are: 1: low; 2: high; 3: was low and high in the period.",
+        "Node": "qachannels/3/triggers/1/value",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/averaging/count": {
+        "Description": "Configures the number of Scope measurements to average.",
+        "Node": "scopes/0/averaging/count",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/averaging/enable": {
+        "Description": "Enables averaging of Scope measurements.",
+        "Node": "scopes/0/averaging/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/0/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/0/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/0/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/0/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2.",
+            "2": "\"chan2sigin\", \"channel2_signal_input\": Signal Input Channel 3.",
+            "3": "\"chan3sigin\", \"channel3_signal_input\": Signal Input Channel 4."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/0/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/0/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/1/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/1/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/1/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/1/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2.",
+            "2": "\"chan2sigin\", \"channel2_signal_input\": Signal Input Channel 3.",
+            "3": "\"chan3sigin\", \"channel3_signal_input\": Signal Input Channel 4."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/1/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/1/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/2/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/2/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/2/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/2/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2.",
+            "2": "\"chan2sigin\", \"channel2_signal_input\": Signal Input Channel 3.",
+            "3": "\"chan3sigin\", \"channel3_signal_input\": Signal Input Channel 4."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/2/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/2/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/3/enable": {
+        "Description": "Enables recording for this Scope channel.",
+        "Node": "scopes/0/channels/3/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "Dependent"
+    },
+    "scopes/0/channels/3/inputselect": {
+        "Description": "Selects the scope input signal.",
+        "Node": "scopes/0/channels/3/inputselect",
+        "Options": {
+            "0": "\"chan0sigin\", \"channel0_signal_input\": Signal Input Channel 1.",
+            "1": "\"chan1sigin\", \"channel1_signal_input\": Signal Input Channel 2.",
+            "2": "\"chan2sigin\", \"channel2_signal_input\": Signal Input Channel 3.",
+            "3": "\"chan3sigin\", \"channel3_signal_input\": Signal Input Channel 4."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/channels/3/wave": {
+        "Description": "Contains the acquired Scope measurement data.",
+        "Node": "scopes/0/channels/3/wave",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "Dependent"
+    },
+    "scopes/0/enable": {
+        "Description": "Enables the acquisition of Scope shots. Goes back to 0 (disabled) after the scope shot has been acquired.",
+        "Node": "scopes/0/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/length": {
+        "Description": "Defines the length of the recorded Scope shot in number of samples.",
+        "Node": "scopes/0/length",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/segments/count": {
+        "Description": "Specifies the number of segments to be recorded in device memory. The maximum Scope shot size is given by the available memory divided by the number of segments.",
+        "Node": "scopes/0/segments/count",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/segments/enable": {
+        "Description": "Enable segmented Scope recording. This allows for full bandwidth recording of Scope shots with a minimum dead time between individual shots.",
+        "Node": "scopes/0/segments/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/single": {
+        "Description": "Puts the Scope into single shot mode.",
+        "Node": "scopes/0/single",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "scopes/0/time": {
+        "Description": "Defines the time base of the Scope.",
+        "Node": "scopes/0/time",
+        "Options": {
+            "0": "2 GHz"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/trigger/channel": {
+        "Description": "Selects the trigger source signal.",
+        "Node": "scopes/0/trigger/channel",
+        "Options": {
+            "0": "\"chan0trigin0\", \"channel0_trigger_input0\": Channel 1, Trigger Input A.",
+            "1": "\"chan0trigin1\", \"channel0_trigger_input1\": Channel 1, Trigger Input B.",
+            "1024": "\"swtrig0\", \"software_trigger0\": Software Trigger 1.",
+            "2": "\"chan1trigin0\", \"channel1_trigger_input0\": Channel 2, Trigger Input A.",
+            "3": "\"chan1trigin1\", \"channel1_trigger_input1\": Channel 2, Trigger Input B.",
+            "32": "\"chan0seqtrig0\", \"channel0_sequencer_trigger0\": Channel 1, Sequencer Trigger Output.",
+            "33": "\"chan1seqtrig0\", \"channel1_sequencer_trigger0\": Channel 2, Sequencer Trigger Output.",
+            "34": "\"chan2seqtrig0\", \"channel2_sequencer_trigger0\": Channel 3, Sequencer Trigger Output.",
+            "35": "\"chan3seqtrig0\", \"channel3_sequencer_trigger0\": Channel 4, Sequencer Trigger Output.",
+            "4": "\"chan2trigin0\", \"channel2_trigger_input0\": Channel 3, Trigger Input A.",
+            "5": "\"chan2trigin1\", \"channel2_trigger_input1\": Channel 3, Trigger Input B.",
+            "6": "\"chan3trigin0\", \"channel3_trigger_input0\": Channel 4, Trigger Input A.",
+            "64": "\"chan0seqmon0\", \"channel0_sequencer_monitor0\": Channel 1, Sequencer Monitor Trigger.",
+            "65": "\"chan1seqmon0\", \"channel1_sequencer_monitor0\": Channel 2, Sequencer Monitor Trigger.",
+            "66": "\"chan2seqmon0\", \"channel2_sequencer_monitor0\": Channel 3, Sequencer Monitor Trigger.",
+            "67": "\"chan3seqmon0\", \"channel3_sequencer_monitor0\": Channel 4, Sequencer Monitor Trigger.",
+            "7": "\"chan3trigin1\", \"channel3_trigger_input1\": Channel 4, Trigger Input B."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "scopes/0/trigger/delay": {
+        "Description": "The delay of a Scope measurement. A negative delay results in data being acquired before the trigger point. The resolution is 2 ns.",
+        "Node": "scopes/0/trigger/delay",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "scopes/0/trigger/enable": {
+        "Description": "When triggering is enabled scope data are acquired every time the defined trigger condition is met.",
+        "Node": "scopes/0/trigger/enable",
+        "Options": {
+            "0": "\"off\": OFF: Continuous scope shot acquisition",
+            "1": "\"on\": ON: Trigger based scope shot acquisition"
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/bandwidth": {
+        "Description": "Command streaming bandwidth usage on the physical network connection between device and data server.",
+        "Node": "stats/cmdstream/bandwidth",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Mbit/s"
+    },
+    "stats/cmdstream/bytesreceived": {
+        "Description": "Number of bytes received on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/bytesreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/cmdstream/bytessent": {
+        "Description": "Number of bytes sent on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/bytessent",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/cmdstream/packetslost": {
+        "Description": "Number of command packets lost since device start. Command packets contain device settings that are sent to and received from the device.",
+        "Node": "stats/cmdstream/packetslost",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/packetsreceived": {
+        "Description": "Number of packets received on the command stream from the device since session start.",
+        "Node": "stats/cmdstream/packetsreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/packetssent": {
+        "Description": "Number of packets sent on the command stream to the device since session start.",
+        "Node": "stats/cmdstream/packetssent",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/pending": {
+        "Description": "Number of buffers ready for receiving command packets from the device.",
+        "Node": "stats/cmdstream/pending",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/cmdstream/processing": {
+        "Description": "Number of buffers being processed for command packets. Small values indicate proper performance. For a TCP/IP interface, command packets are sent using the TCP protocol.",
+        "Node": "stats/cmdstream/processing",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/bandwidth": {
+        "Description": "Data streaming bandwidth usage on the physical network connection between device and data server.",
+        "Node": "stats/datastream/bandwidth",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Mbit/s"
+    },
+    "stats/datastream/bytesreceived": {
+        "Description": "Number of bytes received on the data stream from the device since session start.",
+        "Node": "stats/datastream/bytesreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "B"
+    },
+    "stats/datastream/packetslost": {
+        "Description": "Number of data packets lost since device start. Data packets contain measurement data.",
+        "Node": "stats/datastream/packetslost",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/packetsreceived": {
+        "Description": "Number of packets received on the data stream from the device since session start.",
+        "Node": "stats/datastream/packetsreceived",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/pending": {
+        "Description": "Number of buffers ready for receiving data packets from the device.",
+        "Node": "stats/datastream/pending",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/datastream/processing": {
+        "Description": "Number of buffers being processed for data packets. Small values indicate proper performance. For a TCP/IP interface, data packets are sent using the UDP protocol.",
+        "Node": "stats/datastream/processing",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/physical/currents/0": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/1": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/2": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/3": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/currents/4": {
+        "Description": "Provides internal current readings for monitoring.",
+        "Node": "stats/physical/currents/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "mA"
+    },
+    "stats/physical/fanspeeds/0": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/0",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/1": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/1",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/2": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/2",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/3": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/3",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/4": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/4",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fanspeeds/5": {
+        "Description": "Speed of the internal cooling fans for monitoring.",
+        "Node": "stats/physical/fanspeeds/5",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "RPM"
+    },
+    "stats/physical/fpga/aux": {
+        "Description": "Supply voltage of the FPGA.",
+        "Node": "stats/physical/fpga/aux",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/fpga/core": {
+        "Description": "Core voltage of the FPGA.",
+        "Node": "stats/physical/fpga/core",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/fpga/pstemp": {
+        "Description": "Internal temperature of the FPGA's processor system.",
+        "Node": "stats/physical/fpga/pstemp",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/fpga/temp": {
+        "Description": "Internal temperature of the FPGA.",
+        "Node": "stats/physical/fpga/temp",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/overtemperature": {
+        "Description": "This flag is set to a value greater than 0 when the internal temperatures are reaching critical limits.",
+        "Node": "stats/physical/overtemperature",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "stats/physical/sigins/0/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/0/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/0/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/0/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/0/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/0/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/1/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/1/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/1/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/1/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/1/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/2/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/2/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/2/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/2/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/2/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/2/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/2/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/2/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/currents/0": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/3/currents/1": {
+        "Description": "Provides internal current readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigins/3/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/3/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/3/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/3/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigins/3/voltages/0": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/1": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/10": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/11": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/12": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/12",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/13": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/13",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/2": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/3": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/4": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/5": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/6": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/7": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/8": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigins/3/voltages/9": {
+        "Description": "Provides internal voltage measurement on the Signal Input board for monitoring.",
+        "Node": "stats/physical/sigins/3/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/0/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/0/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/0/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/0/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/1/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/1/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/1/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/1/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/2/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/2/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/2/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/2/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/2/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/2/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/2/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/2/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/2/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/2/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/currents/0": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/3/currents/1": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/3/currents/2": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/3/currents/3": {
+        "Description": "Provides internal current readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/sigouts/3/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/3/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/3/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/3/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/sigouts/3/voltages/0": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/1": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/10": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/11": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/11",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/2": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/3": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/4": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/5": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/6": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/7": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/8": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/sigouts/3/voltages/9": {
+        "Description": "Provides internal voltage readings on the Signal Output board for monitoring.",
+        "Node": "stats/physical/sigouts/3/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/currents/0": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/1": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/2": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/3": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/currents/4": {
+        "Description": "Provides internal current readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/currents/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "A"
+    },
+    "stats/physical/synthesizer/temperatures/0": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/1": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/2": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/3": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/temperatures/4": {
+        "Description": "Provides internal temperature readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/temperatures/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/synthesizer/voltages/0": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/1": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/10": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/10",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/2": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/3": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/4": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/5": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/6": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/7": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/8": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/8",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/synthesizer/voltages/9": {
+        "Description": "Provides internal voltage readings on the Synthesizer board for monitoring.",
+        "Node": "stats/physical/synthesizer/voltages/9",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/temperatures/0": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/1": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/2": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/3": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/4": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/5": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/5",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/6": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/6",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/temperatures/7": {
+        "Description": "Provides internal temperature readings for monitoring.",
+        "Node": "stats/physical/temperatures/7",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "\u00b0C"
+    },
+    "stats/physical/voltages/0": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/0",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/1": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/1",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/2": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/2",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/3": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/3",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "stats/physical/voltages/4": {
+        "Description": "Provides internal voltage readings for monitoring.",
+        "Node": "stats/physical/voltages/4",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "V"
+    },
+    "status/adc0max": {
+        "Description": "The maximum value on Signal Input 1 (ADC0) during 100 ms.",
+        "Node": "status/adc0max",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc0min": {
+        "Description": "The minimum value on Signal Input 1 (ADC0) during 100 ms",
+        "Node": "status/adc0min",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc1max": {
+        "Description": "The maximum value on Signal Input 2 (ADC1) during 100 ms.",
+        "Node": "status/adc1max",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/adc1min": {
+        "Description": "The minimum value on Signal Input 2 (ADC1) during 100 ms",
+        "Node": "status/adc1min",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/fifolevel": {
+        "Description": "USB FIFO level: Indicates the USB FIFO fill level inside the device. When 100%, data is lost",
+        "Node": "status/fifolevel",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "status/flags/binary": {
+        "Description": "A set of binary flags giving an indication of the state of various parts of the device. Reserved for future use.",
+        "Node": "status/flags/binary",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/flags/packetlosstcp": {
+        "Description": "Flag indicating if tcp packages have been lost.",
+        "Node": "status/flags/packetlosstcp",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/flags/packetlossudp": {
+        "Description": "Flag indicating if udp packages have been lost.",
+        "Node": "status/flags/packetlossudp",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "status/time": {
+        "Description": "The current timestamp.",
+        "Node": "status/time",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/activeinterface": {
+        "Description": "Currently active interface of the device.",
+        "Node": "system/activeinterface",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/boardrevisions/0": {
+        "Description": "Hardware revision of the motherboard containing the FPGA.",
+        "Node": "system/boardrevisions/0",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/boardrevisions/1": {
+        "Description": "Hardware revision of the Signal Output board.",
+        "Node": "system/boardrevisions/1",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/freq": {
+        "Description": "Indicates the frequency of the reference clock.",
+        "Node": "system/clocks/referenceclock/in/freq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "system/clocks/referenceclock/in/source": {
+        "Description": "The intended reference clock source. When the source is changed, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/in/source",
+        "Options": {
+            "0": "\"internal\": The internal clock is intended to be used as the frequency and time base reference.",
+            "1": "\"external\": An external clock is intended to be used as the frequency and time base reference. Provide a clean and stable 10 MHz or 100 MHz reference to the appropriate back panel connector.",
+            "2": "\"zsync\": The ZSync clock is intended to be used as the frequency and time base reference."
+        },
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/sourceactual": {
+        "Description": "The actual reference clock source.",
+        "Node": "system/clocks/referenceclock/in/sourceactual",
+        "Options": {
+            "0": "\"internal\": The internal clock is used as the frequency and time base reference.",
+            "1": "\"external\": An external clock is used as the frequency and time base reference.",
+            "2": "\"zsync\": The ZSync clock is used as the frequency and time base reference."
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/in/status": {
+        "Description": "Status of the reference clock.",
+        "Node": "system/clocks/referenceclock/in/status",
+        "Options": {
+            "0": "Reference clock has been locked on.",
+            "1": "There was an error locking onto the reference clock signal.",
+            "2": "The device is busy trying to lock onto the reference clock signal."
+        },
+        "Properties": "Read",
+        "Type": "Integer (enumerated)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/out/enable": {
+        "Description": "Enable clock signal on the reference clock output. When the clock output is turned on or off, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/out/enable",
+        "Properties": "Read, Write, Setting",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/clocks/referenceclock/out/freq": {
+        "Description": "Select the frequency of the output reference clock. Only 10 MHz and 100 MHz are allowed. When the frequency is changed, all the instruments connected with ZSync links will be disconnected. The connection should be re-established manually.",
+        "Node": "system/clocks/referenceclock/out/freq",
+        "Properties": "Read, Write, Setting",
+        "Type": "Double",
+        "Unit": "Hz"
+    },
+    "system/fpgarevision": {
+        "Description": "HDL firmware revision.",
+        "Node": "system/fpgarevision",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/fwlog": {
+        "Description": "Returns log output of the firmware.",
+        "Node": "system/fwlog",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/fwlogenable": {
+        "Description": "Enables logging to the fwlog node.",
+        "Node": "system/fwlogenable",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/fwrevision": {
+        "Description": "Revision of the device-internal controller software.",
+        "Node": "system/fwrevision",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/identify": {
+        "Description": "Setting this node to 1 will cause all frontpanel LEDs to blink for 5 seconds, then return to their previous state.",
+        "Node": "system/identify",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/interfacespeed": {
+        "Description": "Speed of the currently active interface (USB only).",
+        "Node": "system/interfacespeed",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultgateway": {
+        "Description": "Default gateway configuration for the network connection.",
+        "Node": "system/nics/0/defaultgateway",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultip4": {
+        "Description": "IPv4 address of the device to use if static IP is enabled.",
+        "Node": "system/nics/0/defaultip4",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/defaultmask": {
+        "Description": "IPv4 mask in case of static IP.",
+        "Node": "system/nics/0/defaultmask",
+        "Properties": "Read, Write",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/gateway": {
+        "Description": "Current network gateway.",
+        "Node": "system/nics/0/gateway",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/ip4": {
+        "Description": "Current IPv4 of the device.",
+        "Node": "system/nics/0/ip4",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/mac": {
+        "Description": "Current MAC address of the device network interface.",
+        "Node": "system/nics/0/mac",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/mask": {
+        "Description": "Current network mask.",
+        "Node": "system/nics/0/mask",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/nics/0/saveip": {
+        "Description": "If written, this action will program the defined static IP address to the device.",
+        "Node": "system/nics/0/saveip",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/nics/0/static": {
+        "Description": "Enable this flag if the device is used in a network with fixed IP assignment without a DHCP server.",
+        "Node": "system/nics/0/static",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/owner": {
+        "Description": "Returns the current owner of the device (IP).",
+        "Node": "system/owner",
+        "Properties": "Read",
+        "Type": "String",
+        "Unit": "None"
+    },
+    "system/properties/freqresolution": {
+        "Description": "The number of bits used to represent a frequency.",
+        "Node": "system/properties/freqresolution",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/properties/freqscaling": {
+        "Description": "The scale factor to use to convert a frequency represented as a freqresolution-bit integer to a floating point value.",
+        "Node": "system/properties/freqscaling",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/maxfreq": {
+        "Description": "The maximum oscillator frequency that can be set.",
+        "Node": "system/properties/maxfreq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/maxtimeconstant": {
+        "Description": "The maximum demodulator time constant that can be set.",
+        "Node": "system/properties/maxtimeconstant",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/minfreq": {
+        "Description": "The minimum oscillator frequency that can be set.",
+        "Node": "system/properties/minfreq",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/mintimeconstant": {
+        "Description": "The minimum demodulator time constant that can be set.",
+        "Node": "system/properties/mintimeconstant",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "None"
+    },
+    "system/properties/negativefreq": {
+        "Description": "Indicates whether negative frequencies are supported.",
+        "Node": "system/properties/negativefreq",
+        "Properties": "Read",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/properties/timebase": {
+        "Description": "Minimal time difference between two timestamps. The value is equal to 1/(maximum sampling rate).",
+        "Node": "system/properties/timebase",
+        "Properties": "Read",
+        "Type": "Double",
+        "Unit": "s"
+    },
+    "system/shutdown": {
+        "Description": "Sending a '1' to this node initiates a shutdown of the operating system on the device. It is recommended to trigger this shutdown before switching the device off with the hardware switch at the back side of the device.",
+        "Node": "system/shutdown",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/stall": {
+        "Description": "Indicates if the network connection is stalled.",
+        "Node": "system/stall",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/swtriggers/0/single": {
+        "Description": "Issues a single software trigger event.",
+        "Node": "system/swtriggers/0/single",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    },
+    "system/update": {
+        "Description": "Requests update of the device firmware and bitstream from the dataserver.",
+        "Node": "system/update",
+        "Properties": "Read, Write",
+        "Type": "Integer (64 bit)",
+        "Unit": "None"
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ networkx
 qutechopenql
 spirack
 zhinst
+zhinst-deviceutils
 packaging
 deprecated
 adaptive>=0.10.0


### PR DESCRIPTION
First draft of an SHFQA driver reproducing as best as possible the existing interface of UHFQA_core + UHFQC

Changes proposed in this pull request:
- introduce dependency to zhinst-deviceutils package (https://pypi.org/project/zhinst-deviceutils/)
- add parameter files for SHFQA2 and SHFQA4
- compute awg index via dedicated method in ZI_base_instrument instead of hardcoded ch // 2
- SHFQA code

WARNING:
- The code is not yet sufficiently tested to be used in a production environment
- There is no support yet for DIO calibration

@tonyp-zi 



