### PR TITLE
Add dio parity checks for HDAWG

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
@@ -60,9 +60,9 @@ class ZI_HDAWG_core(zibase.ZI_base_instrument):
     """
 
     # Define minimum required revisions
-    MIN_FWREVISION = 62730
-    MIN_FPGAREVISION = 62832
-    MIN_SLAVEREVISION = 62659
+    MIN_FWREVISION = 68286
+    MIN_FPGAREVISION = 68286
+    MIN_SLAVEREVISION = 68286
 
     ##########################################################################
     # 'public' functions: device control

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -742,8 +742,6 @@ class ZI_base_instrument(Instrument):
         self._errors = None
         # Structure for storing errors that should be demoted to warnings
         self._errors_to_ignore = []
-        # Make initial error check
-        self.check_errors()
 
         # Default is not to use async mode
         self._async_mode = False
@@ -753,6 +751,9 @@ class ZI_base_instrument(Instrument):
             self._logfile = open(logfile, 'w')
         else:
             self._logfile = None
+
+        # Make initial error check
+        self.check_errors()
 
         # Show some info
         serial = self.get('features_serial')


### PR DESCRIPTION
This PR implements support for DIO parity checks on the ZI HDAWG at the PycQED driver level. 

Related issue: https://github.com/DiCarloLab-Delft/QuSurf-IssueTracker/issues/211

- Override base class methods checking for errors to also account for DIO parity check errors
- Ignore errors generated during DIO calibration

