### PR TITLE
Dissolve for loop that concatenate strings to str.join

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/internal/_shfqa.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/internal/_shfqa.py
@@ -448,9 +448,7 @@ class SeqC:
             body: string enclosed within brackets.
         """
         try:
-            string = ""
-            for line in body:
-                string += line
+            string = "".join([line for line in body])
             body = string
         except TypeError:
             pass


### PR DESCRIPTION
Please use the following template for a pull request. 

Changes proposed in this pull request:
- dissolve the for loop that concatenates strings to Python API join



