### PR TITLE
Use threading in the UHF multi detector

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQA_core.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/UHFQA_core.py
@@ -1,7 +1,7 @@
 """
     Base driver for the UHFQA instrument including all common functionality.
     Application dependent code can be found in the UHFQuantumController and in the
-    UHFQA_qudev modules. 
+    UHFQA_qudev modules.
 """
 
 import time
@@ -59,7 +59,7 @@ class UHFQA_core(zibase.ZI_base_instrument):
         http://www.zhinst.com/downloads, https://people.zhinst.com/~niels/
     2. upload the latest firmware to the UHFQA using the LabOne GUI
     """
-    
+
     # Define minimum required revisions
     MIN_FWREVISION = 63210
     MIN_FPGAREVISION = 63133
@@ -273,7 +273,7 @@ class UHFQA_core(zibase.ZI_base_instrument):
         self.qas_0_deskew_rows_0_cols_0(1.0)
         self.qas_0_deskew_rows_0_cols_1(0.0)
         self.qas_0_deskew_rows_1_cols_0(0.0)
-        self.qas_0_deskew_rows_1_cols_1(1.0) 
+        self.qas_0_deskew_rows_1_cols_1(1.0)
 
         # Configure the result logger to not do any averaging
         self.qas_0_result_length(1000)
@@ -451,13 +451,13 @@ class UHFQA_core(zibase.ZI_base_instrument):
     # 'public' functions: acquisition support
     ##########################################################################
 
-    def acquisition(self, 
-                    samples=100, 
-                    averages=1, 
-                    acquisition_time=0.010, 
+    def acquisition(self,
+                    samples=100,
+                    averages=1,
+                    acquisition_time=0.010,
                     timeout=10,
-                    channels=(0, 1), 
-                    mode='rl', 
+                    channels=(0, 1),
+                    mode='rl',
                     poll=True):
         self.timeout(timeout)
         self.acquisition_initialize(samples, averages, channels, mode, poll)
@@ -469,12 +469,12 @@ class UHFQA_core(zibase.ZI_base_instrument):
 
         return data
 
-    def acquisition_initialize(self, 
-                               samples, 
+    def acquisition_initialize(self,
+                               samples,
                                averages,
                                loop_cnt = None,
                                channels=(0, 1),
-                               mode='rl', 
+                               mode='rl',
                                poll=True) -> None:
         # Define the channels to use and subscribe to them
         self._acquisition_nodes = []
@@ -533,7 +533,7 @@ class UHFQA_core(zibase.ZI_base_instrument):
 
         # Generate more dummy data
         self.auxins_0_averaging(8)
-    
+
     def acquisition_arm(self, single=True) -> None:
         # time.sleep(0.01)
         self.awgs_0_single(single)
@@ -560,9 +560,9 @@ class UHFQA_core(zibase.ZI_base_instrument):
 
         # Acquire data
         gotem = [False]*len(self._acquisition_nodes)
-        accumulated_time = 0
+        start_time = time.time()
 
-        while accumulated_time < self.timeout() and not all(gotem):
+        while (time.time() - start_time) < self.timeout() and not all(gotem):
             dataset = self.poll(acquisition_time)
 
             # Enable the user to interrupt long (or buggy) acquisitions
@@ -579,14 +579,13 @@ class UHFQA_core(zibase.ZI_base_instrument):
                         data[n] = np.concatenate((data[n], v['vector']))
                         if len(data[n]) >= samples:
                             gotem[n] = True
-            accumulated_time += acquisition_time
 
         if not all(gotem):
             self.acquisition_finalize()
             for n, _c in enumerate(self._acquisition_nodes):
                 if n in data:
-                    print("\t: Channel {}: Got {} of {} samples".format(
-                          n, len(data[n]), samples))
+                    print("\t{}: Channel {}: Got {} of {} samples".format(
+                          self.devname, n, len(data[n]), samples))
             raise TimeoutError("Error: Didn't get all results!")
 
         return data


### PR DESCRIPTION
Please use the following template for a pull request. 

Fixes #issuenumber.

Changes proposed in this pull request:
- Threaded the outer loop over detectors in the Mulit_Detector_UHF class
- Improved timeout detection in the UHFQA core class

@mariosk-zi @leodicarlo 

In order for the pull request to be merged, the following conditions must be met:
- test suite (Github actions) passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


