### PR TITLE
Julias zi/adapt_hd_dio_calib

### DIFF
--- a/pycqed/instrument_drivers/library/DIO.py
+++ b/pycqed/instrument_drivers/library/DIO.py
@@ -138,6 +138,13 @@ _control_modes = {
             [27, 26, 25]
         ],
         "trigger_bits": [31,15]
+    },
+    "calibration":{
+        "control_bits":[
+            [30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16],
+            [32]
+        ],
+        "trigger_bits": [16]
     }
 }
 

--- a/pycqed/instrument_drivers/physical_instruments/QuTech/CC.py
+++ b/pycqed/instrument_drivers/physical_instruments/QuTech/CC.py
@@ -304,6 +304,20 @@ class CC(CCCore, Instrument, DIO.CalInterface):
                                  (3, list(staircase_sequence+ (staircase_sequence << 3)))]
             dio_mask = 0x8FFF8FFF
 
+        elif dio_mode == "hdawg":
+            cc_prog = inspect.cleandoc("""
+                        mainLoop:   seq_out         0xFFFF0000,1        
+                                    seq_out         0x00000000,1
+                                    jmp             @mainLoop
+                        """)
+
+            dio_mask = 0xbfff0000
+
+            expected_sequence = [(0, [1023]),
+                                 (1, [1023]),
+                                 (2, [1]),
+                                 (3, [1])]
+
 
         elif dio_mode == "uhfqa":  # FIXME: no official mode yet
             cc_prog = inspect.cleandoc("""

--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG8.py
@@ -218,7 +218,7 @@ class ZI_HDAWG8(zicore.ZI_HDAWG_core, DIO.CalInterface):
 
         self.add_parameter(
             'cfg_codeword_protocol', initial_value='identical',
-            vals=validators.Enum('identical', 'microwave', 'novsm_microwave', 'flux'), docstring=(
+            vals=validators.Enum('identical', 'microwave', 'novsm_microwave', 'flux', "calibration"), docstring=(
                 'Used in the configure codeword method to determine what DIO'
                 ' pins are used in for which AWG numbers.'),
             parameter_class=ManualParameter)
@@ -567,7 +567,7 @@ while (1) {
 
         return False
 
-    def _find_valid_delays(self, awgs_and_sequences):
+    def _find_valid_delays(self, awgs_and_sequences, dio_mask):
         """Finds valid DIO delay settings for a given AWG by testing all allowed delay settings for timing violations on the
         configured bits. In addition, it compares the recorded DIO codewords to an expected sequence to make sure that no
         codewords are sampled incorrectly."""
@@ -575,11 +575,13 @@ while (1) {
         valid_delays= []
         for delay in range(16):
             log.debug(f'   Testing delay {delay}')
-            self.setd('raw/dios/0/delays/*/value', delay)
-            time.sleep(1)
+            for index in range(32):
+                self.setd(f'raw/dios/*/delays/{index}/value', delay)
+            self.seti('raw/dios/*/error/timingclear', 1)
+            time.sleep(3)
             valid_sequence = True
             for awg, sequence in awgs_and_sequences:
-                if self.geti('awgs/' + str(awg) + '/dio/error/timing') == 0:
+                if self.geti('raw/dios/0/error/timingsticky') == 0:
                     ts, cws = self._get_awg_dio_data(awg)
                     index = None
                     last_index = None
@@ -605,7 +607,6 @@ while (1) {
 
             if valid_sequence:
                 valid_delays.append(delay)
-
         return set(valid_delays)
 
     ##########################################################################
@@ -640,14 +641,17 @@ while (1) {
 
     def calibrate_dio_protocol(self, dio_mask: int, expected_sequence: List, port: int=0):
         # FIXME: UHF driver does not use expected_sequence, why the difference
+
         self.assure_ext_clock()
         self.upload_codeword_program()
 
         for awg, sequence in expected_sequence:
             if not self._ensure_activity(awg, mask_value=dio_mask):
                 raise ziDIOActivityError('No or insufficient activity found on the DIO bits associated with AWG {}'.format(awg))
-
-        valid_delays = self._find_valid_delays(expected_sequence)
+        # self.setd('awgs/*/dio/mask/shift', 0)
+        # self.setd('awgs/0/dio/mask/value', 0)
+        valid_delays = self._find_valid_delays(expected_sequence, dio_mask)
+        print(valid_delays)
         if len(valid_delays) == 0:
             raise ziDIOCalibrationError('DIO calibration failed! No valid delays found')
 

--- a/pycqed/measurement/qcodes_QtPlot_monkey_patching.py
+++ b/pycqed/measurement/qcodes_QtPlot_monkey_patching.py
@@ -75,8 +75,8 @@ import inspect
 
 # Below: patch the QtPlot method to allow for setting a fixed color scale range
 
-import qcodes
-from qcodes.plots.pyqtgraph import QtPlot
+import qcodes_loop
+from qcodes_loop.plots.pyqtgraph import QtPlot
 
 
 def dummy_func(hist, **kwargs):
@@ -124,7 +124,7 @@ ast.fix_missing_locations(parsedQtPlotSource)
 # Compile and execute the code in the namespace of the "pyqtgraph" module
 # such that on next import of QtPlot the patched version will be used
 co = compile(parsedQtPlotSource, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)
 
 
 # Patch the color scales
@@ -141,15 +141,15 @@ parsed_colorscales = ast.parse(str_colorscales)
 parsed_colorscales_raw = ast.parse(str_colorscales_raw)
 
 co = compile(parsed_colorscales, "<string>", "exec")
-exec(co, qcodes.plots.colors.__dict__)
+exec(co, qcodes_loop.plots.colors.__dict__)
 co = compile(parsed_colorscales_raw, "<string>", "exec")
-exec(co, qcodes.plots.colors.__dict__)
+exec(co, qcodes_loop.plots.colors.__dict__)
 
 
 # On some systems this is also required probably because the colors get imported
 # there as well and, depending on the python version, the reference doesn't
 # change everywhere
 co = compile(parsed_colorscales, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)
 co = compile(parsed_colorscales_raw, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)


### PR DESCRIPTION
Changes proposed in this pull request:
- adapt DIO calibration of the HDAWG
- replace qcodes with qcodes_loop in library imports

@MiniSean @wvlothuizen 

In order for the pull request to be merged, the following conditions must be met:
- test suite (Github actions) passes
- all reasonable issues raised by codacy must be resolved 
- a positive review is required

Whenever possible the pull request should
- follow the PEP8 style guide 
- have tests for the code
- be well documented and contain comments

Tests are not mandatory as this is generally hard to make for instruments that interact with hardware. 


