### PR TITLE
Replacing deprecated functions

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/LutMans/flux_lutman.py
+++ b/pycqed/instrument_drivers/meta_instrument/LutMans/flux_lutman.py
@@ -14,7 +14,7 @@ except ImportError:
     pass  # This is to make the lutman work if no OpenQL is installed.
 
 import PyQt5
-from qcodes.plots.pyqtgraph import QtPlot
+from qcodes_loop.plots.pyqtgraph import QtPlot
 import matplotlib.pyplot as plt
 from pycqed.analysis.tools.plotting import set_xlabel, set_ylabel
 import time

--- a/pycqed/instrument_drivers/meta_instrument/LutMans/flux_lutman_vcz.py
+++ b/pycqed/instrument_drivers/meta_instrument/LutMans/flux_lutman_vcz.py
@@ -8,7 +8,7 @@ from pycqed.measurement.waveform_control_CC import waveforms_flux as wfl
 from pycqed.measurement.waveform_control_CC import waveforms_vcz as wf_vcz
 
 import PyQt5
-from qcodes.plots.pyqtgraph import QtPlot
+from qcodes_loop.plots.pyqtgraph import QtPlot
 import matplotlib.pyplot as plt
 from pycqed.analysis.tools.plotting import set_xlabel, set_ylabel
 import time

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -54,7 +54,7 @@ from pycqed.measurement.sweep_functions import Sweep_function
 from qcodes.instrument.base import Instrument
 from qcodes.instrument.parameter import ManualParameter
 from qcodes.utils import validators as vals
-from qcodes.plots.colors import color_cycle
+from qcodes_loop.plots.colors import color_cycle
 
 
 from . import measurement_control_helpers as mch
@@ -79,7 +79,7 @@ try:
     # That line was moved into the `__init__.py` of pycqed so that
     # `QtPlot` can be imported from qcodes with all the modifications
 
-    from qcodes.plots.pyqtgraph import QtPlot, TransformState
+    from qcodes_loop.plots.pyqtgraph import QtPlot, TransformState
 except Exception:
     print(
         "pyqtgraph plotting not supported, "

--- a/pycqed/measurement/qcodes_QtPlot_monkey_patching.py
+++ b/pycqed/measurement/qcodes_QtPlot_monkey_patching.py
@@ -76,7 +76,8 @@ import inspect
 # Below: patch the QtPlot method to allow for setting a fixed color scale range
 
 import qcodes
-from qcodes.plots.pyqtgraph import QtPlot
+from qcodes_loop.plots.pyqtgraph import QtPlot
+import qcodes_loop
 
 
 def dummy_func(hist, **kwargs):
@@ -124,7 +125,7 @@ ast.fix_missing_locations(parsedQtPlotSource)
 # Compile and execute the code in the namespace of the "pyqtgraph" module
 # such that on next import of QtPlot the patched version will be used
 co = compile(parsedQtPlotSource, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)
 
 
 # Patch the color scales
@@ -141,15 +142,15 @@ parsed_colorscales = ast.parse(str_colorscales)
 parsed_colorscales_raw = ast.parse(str_colorscales_raw)
 
 co = compile(parsed_colorscales, "<string>", "exec")
-exec(co, qcodes.plots.colors.__dict__)
+exec(co, qcodes_loop.plots.colors.__dict__)
 co = compile(parsed_colorscales_raw, "<string>", "exec")
-exec(co, qcodes.plots.colors.__dict__)
+exec(co, qcodes_loop.plots.colors.__dict__)
 
 
 # On some systems this is also required probably because the colors get imported
 # there as well and, depending on the python version, the reference doesn't
 # change everywhere
 co = compile(parsed_colorscales, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)
 co = compile(parsed_colorscales_raw, "<string>", "exec")
-exec(co, qcodes.plots.pyqtgraph.__dict__)
+exec(co, qcodes_loop.plots.pyqtgraph.__dict__)


### PR DESCRIPTION
Necessary fixes to imports, where deprecated functions/methods were being used. All those have been replaced with working ones. Necessary changes for the SHFPPC calibration script to run.

